### PR TITLE
chore(deploy-camunda): replace the hand-rolled worker pool and the duplicate result struct

### DIFF
--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -168,6 +168,22 @@ func (c *Client) ListNamespacedResources(
 	return resources, nil
 }
 
+// ListPods returns every pod in a namespace using the typed client. Callers that
+// need container-level state (waiting reasons, image-pull messages) should use
+// this rather than ListNamespacedResources, which hands back unstructured data
+// that has to be traversed by hand.
+func (c *Client) ListPods(ctx context.Context, namespace string) (*corev1.PodList, error) {
+	if namespace == "" {
+		return nil, errors.New("namespace must not be empty")
+	}
+
+	pods, err := c.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods in namespace %q: %w", namespace, err)
+	}
+	return pods, nil
+}
+
 func (c *Client) EnsureNamespace(ctx context.Context, namespace string) error {
 	if namespace == "" {
 		return errors.New("namespace must not be empty")

--- a/scripts/camunda-core/pkg/kube/kube_pods_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_pods_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestListPods(t *testing.T) {
+	pod := func(name, namespace string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	}
+
+	t.Run("returns pods scoped to the namespace", func(t *testing.T) {
+		client := newTestClient(pod("a", "target"), pod("b", "target"), pod("c", "other"))
+
+		pods, err := client.ListPods(context.Background(), "target")
+		if err != nil {
+			t.Fatalf("ListPods() error = %v", err)
+		}
+		if len(pods.Items) != 2 {
+			t.Fatalf("got %d pods, want 2", len(pods.Items))
+		}
+		for _, p := range pods.Items {
+			if p.Namespace != "target" {
+				t.Errorf("pod %q leaked from namespace %q", p.Name, p.Namespace)
+			}
+		}
+	})
+
+	t.Run("carries container statuses through", func(t *testing.T) {
+		p := pod("stuck", "target")
+		p.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "postgresql",
+			Image: "registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason:  "ImagePullBackOff",
+					Message: "manifest unknown",
+				},
+			},
+		}}
+		client := newTestClient(p)
+
+		pods, err := client.ListPods(context.Background(), "target")
+		if err != nil {
+			t.Fatalf("ListPods() error = %v", err)
+		}
+		if len(pods.Items) != 1 {
+			t.Fatalf("got %d pods, want 1", len(pods.Items))
+		}
+		waiting := pods.Items[0].Status.ContainerStatuses[0].State.Waiting
+		if waiting == nil || waiting.Reason != "ImagePullBackOff" {
+			t.Fatalf("waiting state not preserved: %+v", waiting)
+		}
+	})
+
+	t.Run("empty namespace is rejected", func(t *testing.T) {
+		client := newTestClient()
+		if _, err := client.ListPods(context.Background(), ""); err == nil {
+			t.Fatal("expected an error for an empty namespace")
+		}
+	})
+
+	t.Run("no pods is not an error", func(t *testing.T) {
+		client := newTestClient()
+		pods, err := client.ListPods(context.Background(), "empty")
+		if err != nil {
+			t.Fatalf("ListPods() error = %v", err)
+		}
+		if len(pods.Items) != 0 {
+			t.Fatalf("got %d pods, want 0", len(pods.Items))
+		}
+	})
+}

--- a/scripts/deploy-camunda/README.md
+++ b/scripts/deploy-camunda/README.md
@@ -705,6 +705,47 @@ Fix: install the operator + CRDs cluster-wide **before** running
 provisions for you. See [Using operators](#using-operators) for how
 to wire an operator-provisioned dependency into a scenario.
 
+### Image cannot be pulled — the deploy aborts instead of timing out
+
+Symptom: the deploy stops after ~1 minute with
+
+```
+helm upgrade --install aborted early: unresolvable container image:
+image "registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17" for
+container "postgresql" in pod "integration-postgresql-0" cannot be pulled ...
+```
+
+This is deliberate. An image the registry will not serve cannot become
+available inside the Helm timeout, so waiting the remaining 19 minutes only
+buys a `context deadline exceeded` that names neither the image nor the
+reason. Two guards produce this:
+
+- **Preflight (before any cluster mutation).** Every image that a resolved
+  values layer pins completely (`registry` + `repository` + `tag`) is
+  resolved on `linux/amd64` — the index *and* the per-platform child
+  manifest it references. An index-only probe passes when the child is
+  missing, which is the exact failure mode of
+  [#6804](https://github.com/camunda/camunda-platform-helm/issues/6804).
+  Scenarios that pin no images resolve nothing and pay no cost.
+- **In-flight guard (during `helm --wait`).** Pods are polled every 15s.
+  When the same container reports `ErrImagePull`/`ImagePullBackOff` with a
+  `not found` / `manifest unknown` registry message on two consecutive
+  polls, the wait is aborted and the error names the pod, container and
+  image.
+
+Auth failures are *not* treated as terminal — they are covered by the
+credential preflight and a retry can still fix them.
+
+Neither guard can make a broken deploy succeed; they only shorten one that
+was already doomed. To opt out:
+
+```bash
+# skip the preflight registry round-trips
+export DEPLOY_CAMUNDA_SKIP_IMAGE_MANIFEST_CHECK=true
+# let the wait run to its timeout instead of aborting
+export DEPLOY_CAMUNDA_IMAGE_PULL_GUARD=off
+```
+
 ### General diagnostics
 
 Two commands cover most first-pass debugging:

--- a/scripts/deploy-camunda/README.md
+++ b/scripts/deploy-camunda/README.md
@@ -720,13 +720,19 @@ available inside the Helm timeout, so waiting the remaining 19 minutes only
 buys a `context deadline exceeded` that names neither the image nor the
 reason. Two guards produce this:
 
-- **Preflight (before any cluster mutation).** Every image that a resolved
-  values layer pins completely (`registry` + `repository` + `tag`) is
-  resolved on `linux/amd64` — the index *and* the per-platform child
-  manifest it references. An index-only probe passes when the child is
-  missing, which is the exact failure mode of
+- **Preflight (before any cluster mutation).** When the resolved values chain
+  includes the enterprise overlay (`values-enterprise.yaml`, reached as
+  `values/features/enterprise.yaml`), every image it pins completely
+  (`registry` + `repository` + `tag`) is resolved on `linux/amd64` — the index
+  *and* the per-platform child manifest it references. An index-only probe
+  passes when the child is missing, which is the exact failure mode of
   [#6804](https://github.com/camunda/camunda-platform-helm/issues/6804).
-  Scenarios that pin no images resolve nothing and pay no cost.
+  Scenarios without the overlay make no registry calls at all.
+
+  Only one condition fails the preflight: the registry serves the index and then
+  denies the child that index advertises. Anything that merely prevents the
+  check from running — no Docker binary, no credentials, no network — is a
+  warning, because it says nothing about the images.
 - **In-flight guard (during `helm --wait`).** Pods are polled every 15s.
   When the same container reports `ErrImagePull`/`ImagePullBackOff` with a
   `not found` / `manifest unknown` registry message on two consecutive

--- a/scripts/deploy-camunda/deploy/enterprise_images.go
+++ b/scripts/deploy-camunda/deploy/enterprise_images.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"scripts/camunda-core/pkg/executil"
+)
+
+// Why this check exists, and what it does *not* claim to be.
+//
+// `scripts/check-values-enterprise.sh` validates enterprise image references with
+// `docker manifest inspect`, which resolves the multi-arch *index* and stops
+// there. The failure mode this repository actually keeps hitting is the opposite
+// shape: the index resolves while the per-platform child manifest it references
+// returns 404, so an index-only probe reports a healthy image that no node can
+// pull. See #6921 and #6804.
+//
+// This check reproduces the request sequence containerd performs — resolve the
+// index, then fetch the child manifest for the target platform by digest — so it
+// has the same fidelity as a real pull. It is deliberately *not* a probe of
+// registry retention correctness: a registry-protocol GET can self-heal by
+// re-proxying, so a green result here means "pullable right now", not "correctly
+// cached". Retention correctness is a registry-side concern and lives in
+// camunda/infra-core.
+//
+// Cost is proportional to the number of fully-pinned images in the resolved
+// values chain. Only enterprise overlays pin registry+repository+tag together,
+// so ordinary scenarios resolve zero images and pay nothing.
+
+// defaultImagePlatform is the platform asserted when none is configured. CI
+// nodes and the large majority of customer clusters are linux/amd64, and every
+// incident so far has been amd64-only while arm64 stayed healthy.
+const defaultImagePlatform = "linux/amd64"
+
+// pinnedImage is an image reference that a values layer pins completely.
+type pinnedImage struct {
+	Ref    string // registry/repository:tag
+	Source string // values file it came from
+}
+
+// manifestDescriptor is the subset of an OCI/Docker image index entry we need.
+type manifestDescriptor struct {
+	Digest   string `json:"digest"`
+	Platform struct {
+		OS           string `json:"os"`
+		Architecture string `json:"architecture"`
+		Variant      string `json:"variant"`
+	} `json:"platform"`
+}
+
+// imageIndex is the subset of `docker manifest inspect` output we need. A
+// single-platform image has no "manifests" key, which unmarshals to nil.
+type imageIndex struct {
+	Manifests []manifestDescriptor `json:"manifests"`
+}
+
+// dockerManifestInspect is a package-level variable so tests can drive the check
+// without Docker or network access.
+var dockerManifestInspect = func(ctx context.Context, ref string) ([]byte, error) {
+	return executil.RunCommandCapture(ctx, "docker", []string{"manifest", "inspect", ref}, nil, "")
+}
+
+// collectPinnedImages walks the resolved values layers and returns every image
+// block that pins registry, repository and tag together, deduplicated and
+// sorted.
+//
+// The predicate mirrors the yq expression in check-values-enterprise.sh
+// (`has("registry") and has("repository") and has("tag")`) so both tools agree on
+// what counts as a fully-pinned image.
+func collectPinnedImages(valuesFiles []string) []pinnedImage {
+	seen := map[string]string{}
+	for _, file := range valuesFiles {
+		doc, err := loadValuesDoc(file)
+		if err != nil || doc == nil {
+			// A layer that cannot be read is the scenario preflight's problem, not
+			// this check's: staying silent avoids reporting the same defect twice.
+			continue
+		}
+		walkImageBlocks(doc, func(_ string, img map[string]any) {
+			ref, ok := fullyPinnedRef(img)
+			if !ok {
+				return
+			}
+			if _, exists := seen[ref]; !exists {
+				seen[ref] = file
+			}
+		})
+	}
+
+	out := make([]pinnedImage, 0, len(seen))
+	for ref, source := range seen {
+		out = append(out, pinnedImage{Ref: ref, Source: source})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Ref < out[j].Ref })
+	return out
+}
+
+// fullyPinnedRef renders "registry/repository:tag" when all three are present
+// and non-empty scalars.
+func fullyPinnedRef(img map[string]any) (string, bool) {
+	registry, okR := nonEmptyScalar(img["registry"])
+	repository, okP := nonEmptyScalar(img["repository"])
+	tag, okT := nonEmptyScalar(img["tag"])
+	if !okR || !okP || !okT {
+		return "", false
+	}
+	return fmt.Sprintf("%s/%s:%s", registry, repository, tag), true
+}
+
+// nonEmptyScalar renders a YAML scalar as a string, rejecting nil and empty.
+// Numeric tags (e.g. `tag: 8.19`) are accepted, since YAML types them as floats.
+func nonEmptyScalar(v any) (string, bool) {
+	if v == nil {
+		return "", false
+	}
+	s := strings.TrimSpace(fmt.Sprintf("%v", v))
+	if s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// imageResolution is the outcome of validating one image reference.
+type imageResolution struct {
+	Ref      string
+	Platform string
+	Digest   string
+	Err      error
+}
+
+// resolveImageForPlatform resolves an image index and asserts that the child
+// manifest for the requested platform is actually fetchable.
+//
+// Three outcomes are treated as success:
+//   - the index advertises the platform and the child manifest fetches;
+//   - the reference is a single-platform manifest with no index (no children to
+//     check, so resolving the reference is the whole assertion);
+//   - the index advertises no entry for the platform at all — that is an image
+//     that was never built for it, not a broken cache, and is not this check's
+//     business.
+func resolveImageForPlatform(ctx context.Context, ref, platform string) imageResolution {
+	res := imageResolution{Ref: ref, Platform: platform}
+
+	raw, err := dockerManifestInspect(ctx, ref)
+	if err != nil {
+		res.Err = fmt.Errorf("index does not resolve: %w", err)
+		return res
+	}
+
+	var index imageIndex
+	if err := json.Unmarshal(raw, &index); err != nil {
+		res.Err = fmt.Errorf("cannot parse manifest for %s: %w", ref, err)
+		return res
+	}
+	if len(index.Manifests) == 0 {
+		return res // single-platform image, nothing further to assert
+	}
+
+	digest, ok := childDigestForPlatform(index, platform)
+	if !ok {
+		return res // not built for this platform
+	}
+	res.Digest = digest
+
+	// This is the request an index-only check never makes, and the one that
+	// actually failed in the incidents: fetch the child by digest.
+	childRef := repositoryOf(ref) + "@" + digest
+	if _, err := dockerManifestInspect(ctx, childRef); err != nil {
+		res.Err = fmt.Errorf(
+			"index resolves but its %s child manifest %s is not fetchable: %w",
+			platform, digest, err)
+	}
+	return res
+}
+
+// childDigestForPlatform finds the descriptor matching "os/arch". The synthetic
+// "unknown/unknown" entries that attestation manifests carry are skipped by the
+// exact match.
+func childDigestForPlatform(index imageIndex, platform string) (string, bool) {
+	for _, m := range index.Manifests {
+		if m.Platform.OS+"/"+m.Platform.Architecture == platform {
+			return m.Digest, true
+		}
+	}
+	return "", false
+}
+
+// repositoryOf strips the tag from a reference, leaving registry/repository so a
+// digest can be appended. The last colon is only a tag separator when it comes
+// after the last slash — otherwise it is a registry port.
+func repositoryOf(ref string) string {
+	slash := strings.LastIndex(ref, "/")
+	colon := strings.LastIndex(ref, ":")
+	if colon > slash {
+		return ref[:colon]
+	}
+	return ref
+}
+
+// checkPinnedImages asserts that every fully-pinned image in the resolved values
+// chain is pullable on the target platform, children included.
+//
+// Failure semantics: a broken image is StatusFail, because the deploy cannot
+// succeed. Everything else — no pinned images, Docker missing, values layers
+// unresolvable — is OK or a warning, so this check never blocks a deploy for a
+// reason unrelated to image availability.
+func checkPinnedImages(ctx context.Context, valuesFiles []string, platform string) Check {
+	const name = "enterprise image manifests"
+	if platform == "" {
+		platform = defaultImagePlatform
+	}
+
+	images := collectPinnedImages(valuesFiles)
+	if len(images) == 0 {
+		return Check{
+			Name:   name,
+			Status: StatusOK,
+			Detail: "no fully-pinned images in the resolved values chain",
+		}
+	}
+
+	var broken []string
+	checked := 0
+	for _, img := range images {
+		res := resolveImageForPlatform(ctx, img.Ref, platform)
+		if res.Err == nil {
+			checked++
+			continue
+		}
+		broken = append(broken, fmt.Sprintf("%s (from %s): %v", img.Ref, img.Source, res.Err))
+	}
+
+	if len(broken) == 0 {
+		return Check{
+			Name:   name,
+			Status: StatusOK,
+			Detail: fmt.Sprintf("%d image(s) pullable on %s, child manifests included", checked, platform),
+		}
+	}
+
+	return Check{
+		Name:   name,
+		Status: StatusFail,
+		Detail: fmt.Sprintf("%d of %d image(s) not pullable on %s:\n    %s",
+			len(broken), len(images), platform, strings.Join(broken, "\n    ")),
+		Remediation: "the registry cannot serve these references; a pin change will not help if the index resolves " +
+			"but its child manifest does not — see camunda/camunda-platform-helm#6804. " +
+			"Set DEPLOY_CAMUNDA_SKIP_IMAGE_MANIFEST_CHECK=true to deploy anyway",
+	}
+}

--- a/scripts/deploy-camunda/deploy/enterprise_images.go
+++ b/scripts/deploy-camunda/deploy/enterprise_images.go
@@ -26,30 +26,7 @@ import (
 	"scripts/camunda-core/pkg/executil"
 )
 
-// Why this check exists, and what it does *not* claim to be.
-//
-// `scripts/check-values-enterprise.sh` validates enterprise image references with
-// `docker manifest inspect`, which resolves the multi-arch *index* and stops
-// there. The failure mode this repository actually keeps hitting is the opposite
-// shape: the index resolves while the per-platform child manifest it references
-// returns 404, so an index-only probe reports a healthy image that no node can
-// pull. See #6921 and #6804.
-//
-// This check reproduces the request sequence containerd performs — resolve the
-// index, then fetch the child manifest for the target platform by digest — so it
-// has the same fidelity as a real pull. It is deliberately *not* a probe of
-// registry retention correctness: a registry-protocol GET can self-heal by
-// re-proxying, so a green result here means "pullable right now", not "correctly
-// cached". Retention correctness is a registry-side concern and lives in
-// camunda/infra-core.
-//
-// Cost is proportional to the number of fully-pinned images in the resolved
-// values chain. Only enterprise overlays pin registry+repository+tag together,
-// so ordinary scenarios resolve zero images and pay nothing.
-
-// defaultImagePlatform is the platform asserted when none is configured. CI
-// nodes and the large majority of customer clusters are linux/amd64, and every
-// incident so far has been amd64-only while arm64 stayed healthy.
+// defaultImagePlatform is the platform asserted when none is configured.
 const defaultImagePlatform = "linux/amd64"
 
 // pinnedImage is an image reference that a values layer pins completely.
@@ -74,26 +51,20 @@ type imageIndex struct {
 	Manifests []manifestDescriptor `json:"manifests"`
 }
 
-// dockerManifestInspect is a package-level variable so tests can drive the check
-// without Docker or network access.
+// dockerManifestInspect is overridable so tests can drive the check without
+// Docker or network access.
 var dockerManifestInspect = func(ctx context.Context, ref string) ([]byte, error) {
 	return executil.RunCommandCapture(ctx, "docker", []string{"manifest", "inspect", ref}, nil, "")
 }
 
-// collectPinnedImages walks the resolved values layers and returns every image
-// block that pins registry, repository and tag together, deduplicated and
-// sorted.
-//
-// The predicate mirrors the yq expression in check-values-enterprise.sh
-// (`has("registry") and has("repository") and has("tag")`) so both tools agree on
-// what counts as a fully-pinned image.
+// collectPinnedImages walks the given values layers and returns every image
+// block that pins registry, repository and tag together, deduplicated and sorted.
+// The predicate mirrors the yq expression in check-values-enterprise.sh.
 func collectPinnedImages(valuesFiles []string) []pinnedImage {
 	seen := map[string]string{}
 	for _, file := range valuesFiles {
 		doc, err := loadValuesDoc(file)
 		if err != nil || doc == nil {
-			// A layer that cannot be read is the scenario preflight's problem, not
-			// this check's: staying silent avoids reporting the same defect twice.
 			continue
 		}
 		walkImageBlocks(doc, func(_ string, img map[string]any) {
@@ -127,18 +98,9 @@ func fullyPinnedRef(img map[string]any) (string, bool) {
 	return fmt.Sprintf("%s/%s:%s", registry, repository, tag), true
 }
 
-// nonEmptyScalar returns a YAML scalar as a string, and only accepts strings.
-//
-// Non-string scalars are rejected rather than formatted. YAML types an unquoted
-// `tag: 8.10` as a float, and by the time it reaches here it is float64(8.1) —
-// the trailing zero is gone and the original text is unrecoverable. Rendering it
-// would produce "repo:8.1", a reference nobody wrote, and the check would fail an
-// image that is perfectly fine. Skipping is the safe direction: a tag we cannot
-// reconstruct faithfully is simply not asserted.
-//
-// In practice this costs nothing — real tags are either quoted or contain a
-// hyphen or a second dot ("15.18.0-debian-12-r17", "8.19.20"), so YAML already
-// types them as strings.
+// nonEmptyScalar returns a YAML scalar as a string. Only strings are accepted:
+// an unquoted `tag: 8.10` reaches here as float64(8.1), whose original text is
+// unrecoverable, so it is skipped rather than rendered.
 func nonEmptyScalar(v any) (string, bool) {
 	s, ok := v.(string)
 	if !ok {
@@ -151,39 +113,24 @@ func nonEmptyScalar(v any) (string, bool) {
 	return s, true
 }
 
-// imageResolution is the outcome of validating one image reference.
-//
-// Err and Unverified are deliberately distinct. Err means the registry answered
-// and the answer was "this is not here", which is actionable. Unverified means
-// we could not get a trustworthy answer at all — no docker binary, no
-// credentials, no network — which says nothing about the image and must never
-// fail a deploy.
+// imageResolution is the outcome of validating one image reference. Err means
+// the registry answered and the answer was negative; Unverified means no
+// trustworthy answer was obtained. At most one is set.
 type imageResolution struct {
-	Ref      string
-	Platform string
-	Digest   string
-	Err      error
-	// Unverified carries the reason the check could not run, when it could not.
+	Ref        string
+	Platform   string
+	Digest     string
+	Err        error
 	Unverified error
 }
 
 // resolveImageForPlatform resolves an image index and asserts that the child
-// manifest for the requested platform is actually fetchable.
+// manifest for the requested platform is fetchable.
 //
-// Only one condition is reported as a hard failure: **the index resolves and its
-// child for the target platform does not**. That is unambiguous — we
-// authenticated, the registry served the index, and it then denied a digest its
-// own index advertises. It is also exactly the incident shape (#6804).
-//
-// Everything else is Unverified, not a failure:
-//   - no docker binary, no credentials, no network — we learned nothing;
-//   - the index itself not resolving — indistinguishable from the above without
-//     parsing vendor-specific error text, and the in-flight guard catches a
-//     genuinely absent image anyway, with the kubelet's own message.
-//
-// Two outcomes are plain success: a single-platform manifest with no children,
-// and an index that advertises no entry for the target platform (an image never
-// built for it is not a broken image).
+// Err is set only when the index resolves and its child for the target platform
+// does not. A failure to resolve or parse the index sets Unverified. A
+// single-platform manifest, and an index advertising no entry for the platform,
+// both succeed with neither set.
 func resolveImageForPlatform(ctx context.Context, ref, platform string) imageResolution {
 	res := imageResolution{Ref: ref, Platform: platform}
 
@@ -208,8 +155,6 @@ func resolveImageForPlatform(ctx context.Context, ref, platform string) imageRes
 	}
 	res.Digest = digest
 
-	// This is the request an index-only check never makes, and the one that
-	// actually failed in the incidents: fetch the child by digest.
 	childRef := repositoryOf(ref) + "@" + digest
 	if _, err := dockerManifestInspect(ctx, childRef); err != nil {
 		res.Err = fmt.Errorf(
@@ -219,9 +164,8 @@ func resolveImageForPlatform(ctx context.Context, ref, platform string) imageRes
 	return res
 }
 
-// childDigestForPlatform finds the descriptor matching "os/arch". The synthetic
-// "unknown/unknown" entries that attestation manifests carry are skipped by the
-// exact match.
+// childDigestForPlatform finds the descriptor matching "os/arch". The exact
+// match skips the "unknown/unknown" entries attestation manifests carry.
 func childDigestForPlatform(index imageIndex, platform string) (string, bool) {
 	for _, m := range index.Manifests {
 		if m.Platform.OS+"/"+m.Platform.Architecture == platform {
@@ -231,10 +175,7 @@ func childDigestForPlatform(index imageIndex, platform string) (string, bool) {
 	return "", false
 }
 
-// imageCheckConcurrency bounds the parallel registry round-trips. Each
-// `docker manifest inspect` carries its own auth handshake and takes seconds, so
-// checking a dozen images serially would add minutes to every deploy. Bounded so
-// a large values chain cannot hammer the registry.
+// imageCheckConcurrency bounds the parallel registry round-trips.
 const imageCheckConcurrency = 6
 
 // checkedImage pairs a resolution outcome with the layer the image came from.
@@ -271,8 +212,8 @@ func resolveImagesConcurrently(ctx context.Context, images []pinnedImage, platfo
 }
 
 // repositoryOf strips the tag from a reference, leaving registry/repository so a
-// digest can be appended. The last colon is only a tag separator when it comes
-// after the last slash — otherwise it is a registry port.
+// digest can be appended. A colon before the last slash is a registry port, not
+// a tag separator.
 func repositoryOf(ref string) string {
 	slash := strings.LastIndex(ref, "/")
 	colon := strings.LastIndex(ref, ":")
@@ -283,18 +224,9 @@ func repositoryOf(ref string) string {
 }
 
 // enterpriseValuesLayers keeps only the enterprise overlay out of a resolved
-// values chain.
-//
-// Scoping matters: ordinary scenario layers pin images completely too — for
-// example values/identity/keycloak.yaml pins docker.io/camunda/keycloak — so
-// validating every fully-pinned image would put registry round-trips on the
-// critical path of every deploy, for images that have never exhibited this
-// defect. The enterprise overlay is the one that goes through the vendor-ee
-// proxy cache, which is where partially-cached indexes come from.
-//
-// The overlay reaches the chain as values/features/enterprise.yaml, a symlink to
-// the chart-root values-enterprise.yaml, so both names are accepted and symlinks
-// are resolved before matching.
+// values chain. The overlay reaches the chain as values/features/enterprise.yaml,
+// a symlink to the chart-root values-enterprise.yaml, so symlinks are resolved
+// before matching and both names are accepted.
 func enterpriseValuesLayers(files []string) []string {
 	var out []string
 	for _, f := range files {
@@ -310,14 +242,9 @@ func enterpriseValuesLayers(files []string) []string {
 }
 
 // checkPinnedImages asserts that every image pinned by the enterprise overlay is
-// pullable on the target platform, child manifests included.
-//
-// Failure semantics are deliberately asymmetric. Only "the registry served the
-// index and then denied the child it advertises" is a hard failure — the deploy
-// genuinely cannot succeed. Anything that merely prevented the check from
-// running (no docker, no credentials, no network) is a warning: it says nothing
-// about the images, and a preflight must not block a deploy over its own
-// inability to look.
+// pullable on the target platform, child manifests included. It reports
+// StatusFail only for images the registry actively denied, and StatusWarn when
+// the check could not run.
 func checkPinnedImages(ctx context.Context, valuesFiles []string, platform string) Check {
 	const name = "enterprise image manifests"
 	if platform == "" {

--- a/scripts/deploy-camunda/deploy/enterprise_images.go
+++ b/scripts/deploy-camunda/deploy/enterprise_images.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"scripts/camunda-core/pkg/executil"
 )
@@ -125,13 +127,24 @@ func fullyPinnedRef(img map[string]any) (string, bool) {
 	return fmt.Sprintf("%s/%s:%s", registry, repository, tag), true
 }
 
-// nonEmptyScalar renders a YAML scalar as a string, rejecting nil and empty.
-// Numeric tags (e.g. `tag: 8.19`) are accepted, since YAML types them as floats.
+// nonEmptyScalar returns a YAML scalar as a string, and only accepts strings.
+//
+// Non-string scalars are rejected rather than formatted. YAML types an unquoted
+// `tag: 8.10` as a float, and by the time it reaches here it is float64(8.1) —
+// the trailing zero is gone and the original text is unrecoverable. Rendering it
+// would produce "repo:8.1", a reference nobody wrote, and the check would fail an
+// image that is perfectly fine. Skipping is the safe direction: a tag we cannot
+// reconstruct faithfully is simply not asserted.
+//
+// In practice this costs nothing — real tags are either quoted or contain a
+// hyphen or a second dot ("15.18.0-debian-12-r17", "8.19.20"), so YAML already
+// types them as strings.
 func nonEmptyScalar(v any) (string, bool) {
-	if v == nil {
+	s, ok := v.(string)
+	if !ok {
 		return "", false
 	}
-	s := strings.TrimSpace(fmt.Sprintf("%v", v))
+	s = strings.TrimSpace(s)
 	if s == "" {
 		return "", false
 	}
@@ -139,35 +152,50 @@ func nonEmptyScalar(v any) (string, bool) {
 }
 
 // imageResolution is the outcome of validating one image reference.
+//
+// Err and Unverified are deliberately distinct. Err means the registry answered
+// and the answer was "this is not here", which is actionable. Unverified means
+// we could not get a trustworthy answer at all — no docker binary, no
+// credentials, no network — which says nothing about the image and must never
+// fail a deploy.
 type imageResolution struct {
 	Ref      string
 	Platform string
 	Digest   string
 	Err      error
+	// Unverified carries the reason the check could not run, when it could not.
+	Unverified error
 }
 
 // resolveImageForPlatform resolves an image index and asserts that the child
 // manifest for the requested platform is actually fetchable.
 //
-// Three outcomes are treated as success:
-//   - the index advertises the platform and the child manifest fetches;
-//   - the reference is a single-platform manifest with no index (no children to
-//     check, so resolving the reference is the whole assertion);
-//   - the index advertises no entry for the platform at all — that is an image
-//     that was never built for it, not a broken cache, and is not this check's
-//     business.
+// Only one condition is reported as a hard failure: **the index resolves and its
+// child for the target platform does not**. That is unambiguous — we
+// authenticated, the registry served the index, and it then denied a digest its
+// own index advertises. It is also exactly the incident shape (#6804).
+//
+// Everything else is Unverified, not a failure:
+//   - no docker binary, no credentials, no network — we learned nothing;
+//   - the index itself not resolving — indistinguishable from the above without
+//     parsing vendor-specific error text, and the in-flight guard catches a
+//     genuinely absent image anyway, with the kubelet's own message.
+//
+// Two outcomes are plain success: a single-platform manifest with no children,
+// and an index that advertises no entry for the target platform (an image never
+// built for it is not a broken image).
 func resolveImageForPlatform(ctx context.Context, ref, platform string) imageResolution {
 	res := imageResolution{Ref: ref, Platform: platform}
 
 	raw, err := dockerManifestInspect(ctx, ref)
 	if err != nil {
-		res.Err = fmt.Errorf("index does not resolve: %w", err)
+		res.Unverified = fmt.Errorf("could not resolve the index: %w", err)
 		return res
 	}
 
 	var index imageIndex
 	if err := json.Unmarshal(raw, &index); err != nil {
-		res.Err = fmt.Errorf("cannot parse manifest for %s: %w", ref, err)
+		res.Unverified = fmt.Errorf("could not parse the manifest: %w", err)
 		return res
 	}
 	if len(index.Manifests) == 0 {
@@ -185,7 +213,7 @@ func resolveImageForPlatform(ctx context.Context, ref, platform string) imageRes
 	childRef := repositoryOf(ref) + "@" + digest
 	if _, err := dockerManifestInspect(ctx, childRef); err != nil {
 		res.Err = fmt.Errorf(
-			"index resolves but its %s child manifest %s is not fetchable: %w",
+			"the index resolves but its %s child manifest %s is not fetchable: %w",
 			platform, digest, err)
 	}
 	return res
@@ -203,6 +231,45 @@ func childDigestForPlatform(index imageIndex, platform string) (string, bool) {
 	return "", false
 }
 
+// imageCheckConcurrency bounds the parallel registry round-trips. Each
+// `docker manifest inspect` carries its own auth handshake and takes seconds, so
+// checking a dozen images serially would add minutes to every deploy. Bounded so
+// a large values chain cannot hammer the registry.
+const imageCheckConcurrency = 6
+
+// checkedImage pairs a resolution outcome with the layer the image came from.
+type checkedImage struct {
+	ref        string
+	source     string
+	err        error
+	unverified error
+}
+
+// resolveImagesConcurrently validates images in parallel and returns the results
+// in the input order, so the reported list stays deterministic.
+func resolveImagesConcurrently(ctx context.Context, images []pinnedImage, platform string) []checkedImage {
+	results := make([]checkedImage, len(images))
+	sem := make(chan struct{}, imageCheckConcurrency)
+	var wg sync.WaitGroup
+
+	for i, img := range images {
+		wg.Add(1)
+		go func(i int, img pinnedImage) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			res := resolveImageForPlatform(ctx, img.Ref, platform)
+			results[i] = checkedImage{
+				ref: img.Ref, source: img.Source,
+				err: res.Err, unverified: res.Unverified,
+			}
+		}(i, img)
+	}
+	wg.Wait()
+	return results
+}
+
 // repositoryOf strips the tag from a reference, leaving registry/repository so a
 // digest can be appended. The last colon is only a tag separator when it comes
 // after the last slash — otherwise it is a registry port.
@@ -215,54 +282,96 @@ func repositoryOf(ref string) string {
 	return ref
 }
 
-// checkPinnedImages asserts that every fully-pinned image in the resolved values
-// chain is pullable on the target platform, children included.
+// enterpriseValuesLayers keeps only the enterprise overlay out of a resolved
+// values chain.
 //
-// Failure semantics: a broken image is StatusFail, because the deploy cannot
-// succeed. Everything else — no pinned images, Docker missing, values layers
-// unresolvable — is OK or a warning, so this check never blocks a deploy for a
-// reason unrelated to image availability.
+// Scoping matters: ordinary scenario layers pin images completely too — for
+// example values/identity/keycloak.yaml pins docker.io/camunda/keycloak — so
+// validating every fully-pinned image would put registry round-trips on the
+// critical path of every deploy, for images that have never exhibited this
+// defect. The enterprise overlay is the one that goes through the vendor-ee
+// proxy cache, which is where partially-cached indexes come from.
+//
+// The overlay reaches the chain as values/features/enterprise.yaml, a symlink to
+// the chart-root values-enterprise.yaml, so both names are accepted and symlinks
+// are resolved before matching.
+func enterpriseValuesLayers(files []string) []string {
+	var out []string
+	for _, f := range files {
+		name := filepath.Base(f)
+		if resolved, err := filepath.EvalSymlinks(f); err == nil {
+			name = filepath.Base(resolved)
+		}
+		if name == "values-enterprise.yaml" || name == "enterprise.yaml" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// checkPinnedImages asserts that every image pinned by the enterprise overlay is
+// pullable on the target platform, child manifests included.
+//
+// Failure semantics are deliberately asymmetric. Only "the registry served the
+// index and then denied the child it advertises" is a hard failure — the deploy
+// genuinely cannot succeed. Anything that merely prevented the check from
+// running (no docker, no credentials, no network) is a warning: it says nothing
+// about the images, and a preflight must not block a deploy over its own
+// inability to look.
 func checkPinnedImages(ctx context.Context, valuesFiles []string, platform string) Check {
 	const name = "enterprise image manifests"
 	if platform == "" {
 		platform = defaultImagePlatform
 	}
 
-	images := collectPinnedImages(valuesFiles)
+	images := collectPinnedImages(enterpriseValuesLayers(valuesFiles))
 	if len(images) == 0 {
 		return Check{
 			Name:   name,
 			Status: StatusOK,
-			Detail: "no fully-pinned images in the resolved values chain",
+			Detail: "no enterprise image overlay in the resolved values chain",
 		}
 	}
 
-	var broken []string
+	var broken, unverified []string
 	checked := 0
-	for _, img := range images {
-		res := resolveImageForPlatform(ctx, img.Ref, platform)
-		if res.Err == nil {
+	for _, res := range resolveImagesConcurrently(ctx, images, platform) {
+		switch {
+		case res.err != nil:
+			broken = append(broken, fmt.Sprintf("%s (from %s): %v", res.ref, res.source, res.err))
+		case res.unverified != nil:
+			unverified = append(unverified, fmt.Sprintf("%s: %v", res.ref, res.unverified))
+		default:
 			checked++
-			continue
 		}
-		broken = append(broken, fmt.Sprintf("%s (from %s): %v", img.Ref, img.Source, res.Err))
 	}
 
-	if len(broken) == 0 {
+	if len(broken) > 0 {
 		return Check{
 			Name:   name,
-			Status: StatusOK,
-			Detail: fmt.Sprintf("%d image(s) pullable on %s, child manifests included", checked, platform),
+			Status: StatusFail,
+			Detail: fmt.Sprintf("%d of %d enterprise image(s) not pullable on %s:\n    %s",
+				len(broken), len(images), platform, strings.Join(broken, "\n    ")),
+			Remediation: "the registry serves the index but not the platform child it advertises; a pin change " +
+				"will not help — see camunda/camunda-platform-helm#6804. " +
+				"Set DEPLOY_CAMUNDA_SKIP_IMAGE_MANIFEST_CHECK=true to deploy anyway",
+		}
+	}
+
+	if len(unverified) > 0 {
+		return Check{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("could not verify %d of %d enterprise image(s) on %s:\n    %s",
+				len(unverified), len(images), platform, strings.Join(unverified, "\n    ")),
+			Remediation: "install Docker and log in to the registry to enable this check; " +
+				"the in-flight guard still aborts the wait if an image turns out to be unpullable",
 		}
 	}
 
 	return Check{
 		Name:   name,
-		Status: StatusFail,
-		Detail: fmt.Sprintf("%d of %d image(s) not pullable on %s:\n    %s",
-			len(broken), len(images), platform, strings.Join(broken, "\n    ")),
-		Remediation: "the registry cannot serve these references; a pin change will not help if the index resolves " +
-			"but its child manifest does not — see camunda/camunda-platform-helm#6804. " +
-			"Set DEPLOY_CAMUNDA_SKIP_IMAGE_MANIFEST_CHECK=true to deploy anyway",
+		Status: StatusOK,
+		Detail: fmt.Sprintf("%d enterprise image(s) pullable on %s, child manifests included", checked, platform),
 	}
 }

--- a/scripts/deploy-camunda/deploy/enterprise_images.go
+++ b/scripts/deploy-camunda/deploy/enterprise_images.go
@@ -21,7 +21,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
+
+	"golang.org/x/sync/errgroup"
 
 	"scripts/camunda-core/pkg/executil"
 )
@@ -118,6 +119,7 @@ func nonEmptyScalar(v any) (string, bool) {
 // trustworthy answer was obtained. At most one is set.
 type imageResolution struct {
 	Ref        string
+	Source     string // values file the reference came from
 	Platform   string
 	Digest     string
 	Err        error
@@ -178,36 +180,22 @@ func childDigestForPlatform(index imageIndex, platform string) (string, bool) {
 // imageCheckConcurrency bounds the parallel registry round-trips.
 const imageCheckConcurrency = 6
 
-// checkedImage pairs a resolution outcome with the layer the image came from.
-type checkedImage struct {
-	ref        string
-	source     string
-	err        error
-	unverified error
-}
-
 // resolveImagesConcurrently validates images in parallel and returns the results
 // in the input order, so the reported list stays deterministic.
-func resolveImagesConcurrently(ctx context.Context, images []pinnedImage, platform string) []checkedImage {
-	results := make([]checkedImage, len(images))
-	sem := make(chan struct{}, imageCheckConcurrency)
-	var wg sync.WaitGroup
+func resolveImagesConcurrently(ctx context.Context, images []pinnedImage, platform string) []imageResolution {
+	results := make([]imageResolution, len(images))
+	var g errgroup.Group
+	g.SetLimit(imageCheckConcurrency)
 
 	for i, img := range images {
-		wg.Add(1)
-		go func(i int, img pinnedImage) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
+		g.Go(func() error {
 			res := resolveImageForPlatform(ctx, img.Ref, platform)
-			results[i] = checkedImage{
-				ref: img.Ref, source: img.Source,
-				err: res.Err, unverified: res.Unverified,
-			}
-		}(i, img)
+			res.Source = img.Source
+			results[i] = res
+			return nil
+		})
 	}
-	wg.Wait()
+	_ = g.Wait() // every worker records its outcome in results and returns nil
 	return results
 }
 
@@ -247,9 +235,6 @@ func enterpriseValuesLayers(files []string) []string {
 // the check could not run.
 func checkPinnedImages(ctx context.Context, valuesFiles []string, platform string) Check {
 	const name = "enterprise image manifests"
-	if platform == "" {
-		platform = defaultImagePlatform
-	}
 
 	images := collectPinnedImages(enterpriseValuesLayers(valuesFiles))
 	if len(images) == 0 {
@@ -264,10 +249,10 @@ func checkPinnedImages(ctx context.Context, valuesFiles []string, platform strin
 	checked := 0
 	for _, res := range resolveImagesConcurrently(ctx, images, platform) {
 		switch {
-		case res.err != nil:
-			broken = append(broken, fmt.Sprintf("%s (from %s): %v", res.ref, res.source, res.err))
-		case res.unverified != nil:
-			unverified = append(unverified, fmt.Sprintf("%s: %v", res.ref, res.unverified))
+		case res.Err != nil:
+			broken = append(broken, fmt.Sprintf("%s (from %s): %v", res.Ref, res.Source, res.Err))
+		case res.Unverified != nil:
+			unverified = append(unverified, fmt.Sprintf("%s: %v", res.Ref, res.Unverified))
 		default:
 			checked++
 		}

--- a/scripts/deploy-camunda/deploy/enterprise_images_test.go
+++ b/scripts/deploy-camunda/deploy/enterprise_images_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -106,12 +107,24 @@ func TestCollectPinnedImages(t *testing.T) {
 		}
 	})
 
-	t.Run("numeric tags are accepted", func(t *testing.T) {
+	t.Run("unquoted numeric tags are skipped, not guessed", func(t *testing.T) {
 		t.Parallel()
-		path := writeValuesFile(t, "n.yaml", "c:\n  image:\n    registry: r.io\n    repository: repo/img\n    tag: 8.19\n")
+		// YAML types `tag: 8.10` as float64(8.1): the trailing zero is gone before
+		// this code sees it. Rendering it would assert "repo/img:8.1", a reference
+		// nobody wrote, and fail an image that is fine. Skipping is the safe way to
+		// be wrong.
+		path := writeValuesFile(t, "n.yaml", "c:\n  image:\n    registry: r.io\n    repository: repo/img\n    tag: 8.10\n")
+		if got := collectPinnedImages([]string{path}); len(got) != 0 {
+			t.Fatalf("expected the ambiguous tag to be skipped, got %v", got)
+		}
+	})
+
+	t.Run("quoted tags that look numeric are kept verbatim", func(t *testing.T) {
+		t.Parallel()
+		path := writeValuesFile(t, "q.yaml", "c:\n  image:\n    registry: r.io\n    repository: repo/img\n    tag: \"8.10\"\n")
 		got := collectPinnedImages([]string{path})
-		if len(got) != 1 || got[0].Ref != "r.io/repo/img:8.19" {
-			t.Fatalf("got %v, want r.io/repo/img:8.19", got)
+		if len(got) != 1 || got[0].Ref != "r.io/repo/img:8.10" {
+			t.Fatalf("got %v, want r.io/repo/img:8.10", got)
 		}
 	})
 }
@@ -213,7 +226,10 @@ func TestResolveImageForPlatform(t *testing.T) {
 		}
 	})
 
-	t.Run("unresolvable index is reported", func(t *testing.T) {
+	t.Run("an unresolvable index is unverified, not a failure", func(t *testing.T) {
+		// Indistinguishable from missing credentials or a network fault without
+		// parsing vendor error text. The in-flight guard catches a genuinely
+		// absent image with the kubelet's own message.
 		orig := dockerManifestInspect
 		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
 			return nil, errors.New("manifest unknown")
@@ -221,23 +237,97 @@ func TestResolveImageForPlatform(t *testing.T) {
 		defer func() { dockerManifestInspect = orig }()
 
 		res := resolveImageForPlatform(context.Background(), "reg/img:nope", "linux/amd64")
-		if res.Err == nil || !strings.Contains(res.Err.Error(), "index does not resolve") {
-			t.Fatalf("expected an index failure, got %v", res.Err)
+		if res.Err != nil {
+			t.Fatalf("must not hard-fail on an unresolvable index, got %v", res.Err)
+		}
+		if res.Unverified == nil {
+			t.Fatal("expected the reason to be recorded as unverified")
+		}
+	})
+
+	t.Run("a missing docker binary is unverified, not a failure", func(t *testing.T) {
+		// The regression that broke 8 CI jobs: the runner container has no docker
+		// binary, and the check reported every image as broken.
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			return nil, errors.New(`exec: "docker": executable file not found in $PATH`)
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		res := resolveImageForPlatform(context.Background(), "reg/img:1", "linux/amd64")
+		if res.Err != nil {
+			t.Fatalf("a missing tool says nothing about the image, got %v", res.Err)
+		}
+		if res.Unverified == nil {
+			t.Fatal("expected the reason to be recorded as unverified")
 		}
 	})
 }
 
+// entLayer writes the enterprise overlay under its real chain name so the
+// scoping filter accepts it.
+func entLayer(t *testing.T, body string) string {
+	t.Helper()
+	return writeValuesFile(t, "values-enterprise.yaml", body)
+}
+
+func TestEnterpriseValuesLayers(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	write := func(name string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+	overlay := write("values-enterprise.yaml")
+	feature := write("enterprise.yaml")
+	base := write("base.yaml")
+	keycloak := write("keycloak.yaml")
+
+	got := enterpriseValuesLayers([]string{base, keycloak, overlay, feature})
+	if len(got) != 2 {
+		t.Fatalf("got %v, want only the two enterprise layers", got)
+	}
+	for _, f := range got {
+		if n := filepath.Base(f); n != "values-enterprise.yaml" && n != "enterprise.yaml" {
+			t.Errorf("unexpected layer kept: %s", f)
+		}
+	}
+}
+
+func TestEnterpriseValuesLayersFollowsSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "values-enterprise.yaml")
+	if err := os.WriteFile(target, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	// The chain reaches the overlay through values/features/<name>.yaml.
+	link := filepath.Join(dir, "some-feature-name.yaml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if got := enterpriseValuesLayers([]string{link}); len(got) != 1 {
+		t.Fatalf("a symlink to the overlay must be kept, got %v", got)
+	}
+}
+
 func TestCheckPinnedImages(t *testing.T) {
-	t.Run("no pinned images is OK and makes no registry calls", func(t *testing.T) {
+	t.Run("a non-enterprise chain is OK and makes no registry calls", func(t *testing.T) {
+		// The regression: values/identity/keycloak.yaml pins a full triplet too,
+		// so an unscoped check put registry round-trips on every deploy.
 		orig := dockerManifestInspect
 		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
-			t.Fatal("must not touch the registry when nothing is pinned")
+			t.Fatal("must not touch the registry without an enterprise overlay")
 			return nil, nil
 		}
 		defer func() { dockerManifestInspect = orig }()
 
-		path := writeValuesFile(t, "base.yaml", "orchestration:\n  enabled: true\n")
-		got := checkPinnedImages(context.Background(), []string{path}, "linux/amd64")
+		keycloak := writeValuesFile(t, "keycloak.yaml",
+			"identityKeycloak:\n  image:\n    registry: docker.io\n    repository: camunda/keycloak\n    tag: \"26.3.3\"\n")
+		got := checkPinnedImages(context.Background(), []string{keycloak}, "linux/amd64")
 		if got.Status != StatusOK {
 			t.Fatalf("status = %v, detail = %q", got.Status, got.Detail)
 		}
@@ -245,7 +335,10 @@ func TestCheckPinnedImages(t *testing.T) {
 
 	t.Run("a broken child manifest fails the preflight", func(t *testing.T) {
 		orig := dockerManifestInspect
+		var mu sync.Mutex
 		dockerManifestInspect = func(_ context.Context, ref string) ([]byte, error) {
+			mu.Lock()
+			defer mu.Unlock()
 			if strings.Contains(ref, "postgresql@") {
 				return nil, errors.New("manifest unknown")
 			}
@@ -253,23 +346,36 @@ func TestCheckPinnedImages(t *testing.T) {
 		}
 		defer func() { dockerManifestInspect = orig }()
 
-		path := writeValuesFile(t, "values-enterprise.yaml", enterpriseValues)
-		got := checkPinnedImages(context.Background(), []string{path}, "linux/amd64")
+		got := checkPinnedImages(context.Background(), []string{entLayer(t, enterpriseValues)}, "linux/amd64")
 		if got.Status != StatusFail {
 			t.Fatalf("status = %v, want fail; detail = %q", got.Status, got.Detail)
 		}
 		if !strings.Contains(got.Detail, "vendor-ee/postgresql") {
 			t.Errorf("detail should name the broken image, got %q", got.Detail)
 		}
-		if !strings.Contains(got.Detail, "values-enterprise.yaml") {
-			t.Errorf("detail should name the source layer, got %q", got.Detail)
-		}
 		if !strings.Contains(got.Remediation, "6804") {
 			t.Errorf("remediation should point at the tracking issue, got %q", got.Remediation)
 		}
-		// elasticsearch resolves fine; only the two postgresql refs are broken.
 		if !strings.Contains(got.Detail, "2 of 3") {
 			t.Errorf("detail should count the failures, got %q", got.Detail)
+		}
+	})
+
+	t.Run("docker unavailable warns instead of blocking the deploy", func(t *testing.T) {
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			return nil, errors.New(`exec: "docker": executable file not found in $PATH`)
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		got := checkPinnedImages(context.Background(), []string{entLayer(t, enterpriseValues)}, "linux/amd64")
+		if got.Status != StatusWarn {
+			t.Fatalf("status = %v, want warn; detail = %q", got.Status, got.Detail)
+		}
+		// StatusWarn must not fail Report.OK(), or the deploy is blocked again.
+		r := &Report{Checks: []Check{got}}
+		if !r.OK() {
+			t.Fatal("a warning must not block the deploy")
 		}
 	})
 
@@ -280,12 +386,11 @@ func TestCheckPinnedImages(t *testing.T) {
 		}
 		defer func() { dockerManifestInspect = orig }()
 
-		path := writeValuesFile(t, "values-enterprise.yaml", enterpriseValues)
-		got := checkPinnedImages(context.Background(), []string{path}, "linux/amd64")
+		got := checkPinnedImages(context.Background(), []string{entLayer(t, enterpriseValues)}, "linux/amd64")
 		if got.Status != StatusOK {
 			t.Fatalf("status = %v, detail = %q", got.Status, got.Detail)
 		}
-		if !strings.Contains(got.Detail, "3 image(s)") {
+		if !strings.Contains(got.Detail, "3 enterprise image(s)") {
 			t.Errorf("detail should report the count, got %q", got.Detail)
 		}
 	})

--- a/scripts/deploy-camunda/deploy/enterprise_images_test.go
+++ b/scripts/deploy-camunda/deploy/enterprise_images_test.go
@@ -81,8 +81,6 @@ func TestCollectPinnedImages(t *testing.T) {
 				t.Errorf("image[%d] = %q, want %q", i, got[i].Ref, w)
 			}
 		}
-		// os-shell pins registry+repository but no tag, exactly like the real file;
-		// the bash check skips it and so must we.
 		for _, img := range got {
 			if strings.Contains(img.Ref, "os-shell") {
 				t.Errorf("os-shell has no tag and must not be collected, got %q", img.Ref)
@@ -109,10 +107,6 @@ func TestCollectPinnedImages(t *testing.T) {
 
 	t.Run("unquoted numeric tags are skipped, not guessed", func(t *testing.T) {
 		t.Parallel()
-		// YAML types `tag: 8.10` as float64(8.1): the trailing zero is gone before
-		// this code sees it. Rendering it would assert "repo/img:8.1", a reference
-		// nobody wrote, and fail an image that is fine. Skipping is the safe way to
-		// be wrong.
 		path := writeValuesFile(t, "n.yaml", "c:\n  image:\n    registry: r.io\n    repository: repo/img\n    tag: 8.10\n")
 		if got := collectPinnedImages([]string{path}); len(got) != 0 {
 			t.Fatalf("expected the ambiguous tag to be skipped, got %v", got)
@@ -153,8 +147,6 @@ const multiArchIndex = `{"manifests":[
 
 func TestResolveImageForPlatform(t *testing.T) {
 	t.Run("index resolves but the amd64 child 404s", func(t *testing.T) {
-		// The exact 2026-08-19 shape: index OK, child missing. An index-only probe
-		// calls this healthy; this is the regression the whole check exists for.
 		var calls []string
 		orig := dockerManifestInspect
 		dockerManifestInspect = func(_ context.Context, ref string) ([]byte, error) {
@@ -227,9 +219,6 @@ func TestResolveImageForPlatform(t *testing.T) {
 	})
 
 	t.Run("an unresolvable index is unverified, not a failure", func(t *testing.T) {
-		// Indistinguishable from missing credentials or a network fault without
-		// parsing vendor error text. The in-flight guard catches a genuinely
-		// absent image with the kubelet's own message.
 		orig := dockerManifestInspect
 		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
 			return nil, errors.New("manifest unknown")
@@ -246,8 +235,6 @@ func TestResolveImageForPlatform(t *testing.T) {
 	})
 
 	t.Run("a missing docker binary is unverified, not a failure", func(t *testing.T) {
-		// The regression that broke 8 CI jobs: the runner container has no docker
-		// binary, and the check reported every image as broken.
 		orig := dockerManifestInspect
 		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
 			return nil, errors.New(`exec: "docker": executable file not found in $PATH`)
@@ -304,7 +291,6 @@ func TestEnterpriseValuesLayersFollowsSymlink(t *testing.T) {
 	if err := os.WriteFile(target, []byte("{}"), 0o644); err != nil {
 		t.Fatalf("write target: %v", err)
 	}
-	// The chain reaches the overlay through values/features/<name>.yaml.
 	link := filepath.Join(dir, "some-feature-name.yaml")
 	if err := os.Symlink(target, link); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
@@ -316,8 +302,6 @@ func TestEnterpriseValuesLayersFollowsSymlink(t *testing.T) {
 
 func TestCheckPinnedImages(t *testing.T) {
 	t.Run("a non-enterprise chain is OK and makes no registry calls", func(t *testing.T) {
-		// The regression: values/identity/keycloak.yaml pins a full triplet too,
-		// so an unscoped check put registry round-trips on every deploy.
 		orig := dockerManifestInspect
 		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
 			t.Fatal("must not touch the registry without an enterprise overlay")
@@ -372,7 +356,6 @@ func TestCheckPinnedImages(t *testing.T) {
 		if got.Status != StatusWarn {
 			t.Fatalf("status = %v, want warn; detail = %q", got.Status, got.Detail)
 		}
-		// StatusWarn must not fail Report.OK(), or the deploy is blocked again.
 		r := &Report{Checks: []Check{got}}
 		if !r.OK() {
 			t.Fatal("a warning must not block the deploy")

--- a/scripts/deploy-camunda/deploy/enterprise_images_test.go
+++ b/scripts/deploy-camunda/deploy/enterprise_images_test.go
@@ -1,0 +1,308 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeValuesFile drops a values file into a temp dir and returns its path.
+func writeValuesFile(t *testing.T, name, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	return path
+}
+
+// The shape of charts/camunda-platform-8.7/values-enterprise.yaml, trimmed.
+const enterpriseValues = `
+global:
+  security:
+    allowInsecureImages: true
+identityPostgresql:
+  image:
+    registry: registry.camunda.cloud
+    repository: vendor-ee/postgresql
+    tag: 15.18.0-debian-12-r17
+  volumePermissions:
+    image:
+      registry: registry.camunda.cloud
+      repository: vendor-ee/os-shell
+postgresql:
+  image:
+    registry: registry.camunda.cloud
+    repository: vendor-ee/postgresql
+    tag: 14.23.0-debian-12-r19
+elasticsearch:
+  image:
+    registry: registry.camunda.cloud
+    repository: vendor-ee/elasticsearch
+    tag: 8.19.20
+`
+
+func TestCollectPinnedImages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects only fully-pinned triplets, deduplicated and sorted", func(t *testing.T) {
+		t.Parallel()
+		path := writeValuesFile(t, "values-enterprise.yaml", enterpriseValues)
+		got := collectPinnedImages([]string{path})
+
+		want := []string{
+			"registry.camunda.cloud/vendor-ee/elasticsearch:8.19.20",
+			"registry.camunda.cloud/vendor-ee/postgresql:14.23.0-debian-12-r19",
+			"registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17",
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d images %v, want %d", len(got), got, len(want))
+		}
+		for i, w := range want {
+			if got[i].Ref != w {
+				t.Errorf("image[%d] = %q, want %q", i, got[i].Ref, w)
+			}
+		}
+		// os-shell pins registry+repository but no tag, exactly like the real file;
+		// the bash check skips it and so must we.
+		for _, img := range got {
+			if strings.Contains(img.Ref, "os-shell") {
+				t.Errorf("os-shell has no tag and must not be collected, got %q", img.Ref)
+			}
+		}
+	})
+
+	t.Run("ordinary scenario values yield nothing", func(t *testing.T) {
+		t.Parallel()
+		path := writeValuesFile(t, "base.yaml", "orchestration:\n  enabled: true\nidentity:\n  fullURL: http://x\n")
+		if got := collectPinnedImages([]string{path}); len(got) != 0 {
+			t.Fatalf("expected no pinned images, got %v", got)
+		}
+	})
+
+	t.Run("unreadable and empty layers are skipped", func(t *testing.T) {
+		t.Parallel()
+		empty := writeValuesFile(t, "empty.yaml", "")
+		got := collectPinnedImages([]string{empty, "/nonexistent/values.yaml"})
+		if len(got) != 0 {
+			t.Fatalf("expected no images, got %v", got)
+		}
+	})
+
+	t.Run("numeric tags are accepted", func(t *testing.T) {
+		t.Parallel()
+		path := writeValuesFile(t, "n.yaml", "c:\n  image:\n    registry: r.io\n    repository: repo/img\n    tag: 8.19\n")
+		got := collectPinnedImages([]string{path})
+		if len(got) != 1 || got[0].Ref != "r.io/repo/img:8.19" {
+			t.Fatalf("got %v, want r.io/repo/img:8.19", got)
+		}
+	})
+}
+
+func TestRepositoryOf(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ ref, want string }{
+		{"registry.camunda.cloud/vendor-ee/postgresql:15.18.0", "registry.camunda.cloud/vendor-ee/postgresql"},
+		{"localhost:5000/repo/img:1.0", "localhost:5000/repo/img"},
+		// A registry port with no tag must not be mistaken for a tag separator.
+		{"localhost:5000/repo/img", "localhost:5000/repo/img"},
+		{"nginx", "nginx"},
+	}
+	for _, tt := range tests {
+		if got := repositoryOf(tt.ref); got != tt.want {
+			t.Errorf("repositoryOf(%q) = %q, want %q", tt.ref, got, tt.want)
+		}
+	}
+}
+
+const multiArchIndex = `{"manifests":[
+  {"digest":"sha256:amd64digest","platform":{"os":"linux","architecture":"amd64"}},
+  {"digest":"sha256:arm64digest","platform":{"os":"linux","architecture":"arm64"}},
+  {"digest":"sha256:attestation","platform":{"os":"unknown","architecture":"unknown"}}
+]}`
+
+func TestResolveImageForPlatform(t *testing.T) {
+	t.Run("index resolves but the amd64 child 404s", func(t *testing.T) {
+		// The exact 2026-08-19 shape: index OK, child missing. An index-only probe
+		// calls this healthy; this is the regression the whole check exists for.
+		var calls []string
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, ref string) ([]byte, error) {
+			calls = append(calls, ref)
+			if strings.Contains(ref, "@sha256:amd64digest") {
+				return nil, errors.New("manifest unknown")
+			}
+			return []byte(multiArchIndex), nil
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		res := resolveImageForPlatform(context.Background(), "reg/vendor-ee/postgresql:15.18.0", "linux/amd64")
+		if res.Err == nil {
+			t.Fatal("expected the missing child to be reported")
+		}
+		if !strings.Contains(res.Err.Error(), "child manifest") {
+			t.Errorf("error should point at the child, got %v", res.Err)
+		}
+		if len(calls) != 2 {
+			t.Fatalf("expected an index call then a child call, got %v", calls)
+		}
+		if calls[1] != "reg/vendor-ee/postgresql@sha256:amd64digest" {
+			t.Errorf("child fetched by the wrong ref: %q", calls[1])
+		}
+	})
+
+	t.Run("index and child both resolve", func(t *testing.T) {
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			return []byte(multiArchIndex), nil
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		res := resolveImageForPlatform(context.Background(), "reg/img:1", "linux/amd64")
+		if res.Err != nil {
+			t.Fatalf("expected success, got %v", res.Err)
+		}
+		if res.Digest != "sha256:amd64digest" {
+			t.Errorf("digest = %q", res.Digest)
+		}
+	})
+
+	t.Run("single-platform image has no children to check", func(t *testing.T) {
+		calls := 0
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			calls++
+			return []byte(`{"schemaVersion":2,"config":{}}`), nil
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		if res := resolveImageForPlatform(context.Background(), "reg/img:1", "linux/amd64"); res.Err != nil {
+			t.Fatalf("expected success, got %v", res.Err)
+		}
+		if calls != 1 {
+			t.Errorf("expected a single call, got %d", calls)
+		}
+	})
+
+	t.Run("platform not built is not a failure", func(t *testing.T) {
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			return []byte(multiArchIndex), nil
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		if res := resolveImageForPlatform(context.Background(), "reg/img:1", "linux/s390x"); res.Err != nil {
+			t.Fatalf("an image never built for a platform is not broken, got %v", res.Err)
+		}
+	})
+
+	t.Run("unresolvable index is reported", func(t *testing.T) {
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			return nil, errors.New("manifest unknown")
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		res := resolveImageForPlatform(context.Background(), "reg/img:nope", "linux/amd64")
+		if res.Err == nil || !strings.Contains(res.Err.Error(), "index does not resolve") {
+			t.Fatalf("expected an index failure, got %v", res.Err)
+		}
+	})
+}
+
+func TestCheckPinnedImages(t *testing.T) {
+	t.Run("no pinned images is OK and makes no registry calls", func(t *testing.T) {
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			t.Fatal("must not touch the registry when nothing is pinned")
+			return nil, nil
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		path := writeValuesFile(t, "base.yaml", "orchestration:\n  enabled: true\n")
+		got := checkPinnedImages(context.Background(), []string{path}, "linux/amd64")
+		if got.Status != StatusOK {
+			t.Fatalf("status = %v, detail = %q", got.Status, got.Detail)
+		}
+	})
+
+	t.Run("a broken child manifest fails the preflight", func(t *testing.T) {
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, ref string) ([]byte, error) {
+			if strings.Contains(ref, "postgresql@") {
+				return nil, errors.New("manifest unknown")
+			}
+			return []byte(multiArchIndex), nil
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		path := writeValuesFile(t, "values-enterprise.yaml", enterpriseValues)
+		got := checkPinnedImages(context.Background(), []string{path}, "linux/amd64")
+		if got.Status != StatusFail {
+			t.Fatalf("status = %v, want fail; detail = %q", got.Status, got.Detail)
+		}
+		if !strings.Contains(got.Detail, "vendor-ee/postgresql") {
+			t.Errorf("detail should name the broken image, got %q", got.Detail)
+		}
+		if !strings.Contains(got.Detail, "values-enterprise.yaml") {
+			t.Errorf("detail should name the source layer, got %q", got.Detail)
+		}
+		if !strings.Contains(got.Remediation, "6804") {
+			t.Errorf("remediation should point at the tracking issue, got %q", got.Remediation)
+		}
+		// elasticsearch resolves fine; only the two postgresql refs are broken.
+		if !strings.Contains(got.Detail, "2 of 3") {
+			t.Errorf("detail should count the failures, got %q", got.Detail)
+		}
+	})
+
+	t.Run("all images pullable is OK", func(t *testing.T) {
+		orig := dockerManifestInspect
+		dockerManifestInspect = func(_ context.Context, _ string) ([]byte, error) {
+			return []byte(multiArchIndex), nil
+		}
+		defer func() { dockerManifestInspect = orig }()
+
+		path := writeValuesFile(t, "values-enterprise.yaml", enterpriseValues)
+		got := checkPinnedImages(context.Background(), []string{path}, "linux/amd64")
+		if got.Status != StatusOK {
+			t.Fatalf("status = %v, detail = %q", got.Status, got.Detail)
+		}
+		if !strings.Contains(got.Detail, "3 image(s)") {
+			t.Errorf("detail should report the count, got %q", got.Detail)
+		}
+	})
+}
+
+func TestEnvFlagEnabled(t *testing.T) {
+	const name = "DEPLOY_CAMUNDA_TEST_FLAG"
+	for _, v := range []string{"1", "true", "TRUE", "yes", "on"} {
+		t.Setenv(name, v)
+		if !envFlagEnabled(name) {
+			t.Errorf("%q should enable", v)
+		}
+	}
+	for _, v := range []string{"", "0", "false", "off", "maybe"} {
+		t.Setenv(name, v)
+		if envFlagEnabled(name) {
+			t.Errorf("%q should not enable", v)
+		}
+	}
+}

--- a/scripts/deploy-camunda/deploy/preflight.go
+++ b/scripts/deploy-camunda/deploy/preflight.go
@@ -95,13 +95,23 @@ type PreflightOptions struct {
 	// SkipKubeReachability skips the network round-trip that pings the cluster
 	// (used in tests and when only static checks are wanted).
 	SkipKubeReachability bool
+	// SkipImageManifests skips the registry round-trips that assert pinned images
+	// are pullable. Also honored via DEPLOY_CAMUNDA_SKIP_IMAGE_MANIFEST_CHECK.
+	SkipImageManifests bool
 }
 
+// skipImageManifestsEnvVar lets an operator bypass the image manifest check
+// without a code change, for the case where the registry is known-degraded but
+// the deploy is wanted anyway.
+const skipImageManifestsEnvVar = "DEPLOY_CAMUNDA_SKIP_IMAGE_MANIFEST_CHECK"
+
 // Preflight runs all secrets/env checks against the merged flags and returns a
-// Report. It has no side effects: it never writes files, mutates the process
-// environment, or contacts the cluster beyond an optional read-only readiness
-// ping. Sources are resolved exactly as a deploy would see them — process
-// environment overlaid with the configured .env file.
+// Report. It has no side effects: it never writes files or mutates the process
+// environment. It performs two read-only network round-trips — an optional
+// cluster readiness ping, and registry manifest resolution for fully-pinned
+// images — each independently skippable via PreflightOptions. Sources are
+// resolved exactly as a deploy would see them — process environment overlaid
+// with the configured .env file.
 func Preflight(ctx context.Context, flags *config.RuntimeFlags, opts PreflightOptions) *Report {
 	r := &Report{}
 	// baseEnv is process env + .env + ExtraEnv. deployEnv additionally includes the
@@ -125,8 +135,21 @@ func Preflight(ctx context.Context, flags *config.RuntimeFlags, opts PreflightOp
 	r.Checks = append(r.Checks, checkVaultMapping(flags, baseEnv))
 	r.Checks = append(r.Checks, checkScenarioEnv(flags, deployEnv))
 	r.Checks = append(r.Checks, checkCompanionEnv(flags, deployEnv))
+	if !opts.SkipImageManifests && !envFlagEnabled(skipImageManifestsEnvVar) {
+		r.Checks = append(r.Checks, checkPinnedImages(ctx, resolvedScenarioValues(flags), defaultImagePlatform))
+	}
 
 	return r
+}
+
+// envFlagEnabled reports whether an env var is set to an affirmative value.
+func envFlagEnabled(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // effectiveEnv reproduces the env layering buildScenarioEnv uses for presence
@@ -362,22 +385,12 @@ func checkChartPath(flags *config.RuntimeFlags) Check {
 // soft warning rather than a hard fail so `doctor` is still useful when no
 // scenario/chart is configured yet.
 func checkScenarioEnv(flags *config.RuntimeFlags, envMap map[string]string) Check {
-	scenarioList := flags.Deployment.Scenarios
-	if len(scenarioList) == 0 && flags.Deployment.Scenario != "" {
-		for _, s := range strings.Split(flags.Deployment.Scenario, ",") {
-			if t := strings.TrimSpace(s); t != "" {
-				scenarioList = append(scenarioList, t)
-			}
-		}
-	}
+	scenarioList := scenarioNames(flags)
 	if len(scenarioList) == 0 || flags.Chart.ChartPath == "" {
 		return Check{Name: "scenario env vars", Status: StatusOK, Detail: "no scenario/chart configured to scan"}
 	}
 
-	scenarioDir := flags.Deployment.ScenarioPath
-	if scenarioDir == "" {
-		scenarioDir = filepath.Join(flags.Chart.ChartPath, "test/integration/scenarios/chart-full-setup")
-	}
+	scenarioDir := scenarioValuesDir(flags)
 
 	required := map[string]struct{}{}
 	var unresolved []string
@@ -426,6 +439,59 @@ func checkScenarioEnv(flags *config.RuntimeFlags, envMap map[string]string) Chec
 		Remediation: "set the listed vars (run with --interactive to be prompted, or `deploy-camunda config init`)",
 		Missing:     missing,
 	}
+}
+
+// scenarioNames returns the configured scenarios, honoring both the parsed
+// slice and the comma-separated string form.
+func scenarioNames(flags *config.RuntimeFlags) []string {
+	if len(flags.Deployment.Scenarios) > 0 {
+		return flags.Deployment.Scenarios
+	}
+	var out []string
+	for _, s := range strings.Split(flags.Deployment.Scenario, ",") {
+		if t := strings.TrimSpace(s); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// scenarioValuesDir resolves the scenario directory, defaulting to the chart's
+// chart-full-setup tree.
+func scenarioValuesDir(flags *config.RuntimeFlags) string {
+	if flags.Deployment.ScenarioPath != "" {
+		return flags.Deployment.ScenarioPath
+	}
+	return filepath.Join(flags.Chart.ChartPath, "test/integration/scenarios/chart-full-setup")
+}
+
+// resolvedScenarioValues returns every values file a deploy would compose for
+// the configured scenarios. Resolution failures yield no files rather than an
+// error: checkScenarioEnv already reports them, and callers here treat an empty
+// result as "nothing to validate".
+func resolvedScenarioValues(flags *config.RuntimeFlags) []string {
+	scenarioList := scenarioNames(flags)
+	if len(scenarioList) == 0 || flags.Chart.ChartPath == "" {
+		return nil
+	}
+	scenarioDir := scenarioValuesDir(flags)
+
+	var out []string
+	seen := map[string]struct{}{}
+	for _, scenario := range scenarioList {
+		files, err := scenarioLayerFiles(flags, scenarioDir, scenario)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if _, dup := seen[f]; dup {
+				continue
+			}
+			seen[f] = struct{}{}
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // scenarioLayerFiles returns the full set of layered values files a deploy would

--- a/scripts/deploy-camunda/go.mod
+++ b/scripts/deploy-camunda/go.mod
@@ -14,6 +14,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
 	scripts/camunda-core v0.0.0
 	scripts/prepare-helm-values v0.0.0
@@ -71,7 +72,6 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/api v0.31.1 // indirect
 	k8s.io/client-go v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -190,15 +190,47 @@ func upgradeInstall(ctx context.Context, o types.Options) error {
 		args = append(args, o.ExtraArgs...)
 	}
 
-	_, runErr := helmRunWithRetry(ctx, args)
+	runCtx, guard := guardedContext(ctx, o, o.Wait)
+	defer guard.Stop()
+
+	_, runErr := helmRunWithRetry(runCtx, args)
 	if runErr != nil {
 		return &HelmError{
-			Reason:  "helm upgrade --install failed",
+			Reason:  guardedReason("helm upgrade --install failed", guard),
 			Command: "helm " + formatArgs(args),
-			Cause:   runErr,
+			Cause:   guardedCause(runErr, guard),
 		}
 	}
 	return nil
+}
+
+// guardedContext starts the image pull guard for a waiting Helm run, or returns
+// the context untouched with a no-op guard when the run does not wait (nothing
+// to abort) or the guard is disabled.
+func guardedContext(ctx context.Context, o types.Options, waits bool) (context.Context, *imagePullGuard) {
+	if !waits || !imagePullGuardEnabled() {
+		return ctx, noopImagePullGuard()
+	}
+	return startImagePullGuard(ctx, o)
+}
+
+// guardedReason replaces the generic failure reason when the guard is what ended
+// the run, so the error names the actual problem instead of the Helm exit.
+func guardedReason(defaultReason string, guard *imagePullGuard) string {
+	if guard.Stop() != nil {
+		return "helm upgrade --install aborted early: unresolvable container image"
+	}
+	return defaultReason
+}
+
+// guardedCause substitutes the observed image pull failure for the Helm process
+// error. Cancelling the context kills helm, so runErr would otherwise read
+// "signal: killed", which explains nothing.
+func guardedCause(runErr error, guard *imagePullGuard) error {
+	if failure := guard.Stop(); failure != nil {
+		return failure
+	}
+	return runErr
 }
 
 // composeKubeArgs builds kubeconfig and context arguments
@@ -340,13 +372,18 @@ func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.
 		args = append(args, "--set", path+"="+o.CompanionStorageClass)
 	}
 
-	_, runErr := helmRunWithRetry(ctx, args)
+	// Companion charts always pass --wait (see the args above), independently of o.Wait.
+	runCtx, guard := guardedContext(ctx, o, true)
+	defer guard.Stop()
+
+	_, runErr := helmRunWithRetry(runCtx, args)
 	if runErr == nil {
 		return nil
 	}
 	return &HelmError{
-		Reason:  fmt.Sprintf("companion chart %q helm upgrade --install failed", cc.ReleaseName),
+		Reason: guardedReason(
+			fmt.Sprintf("companion chart %q helm upgrade --install failed", cc.ReleaseName), guard),
 		Command: "helm " + formatArgs(args),
-		Cause:   runErr,
+		Cause:   guardedCause(runErr, guard),
 	}
 }

--- a/scripts/deploy-camunda/pkg/deployer/imagepull.go
+++ b/scripts/deploy-camunda/pkg/deployer/imagepull.go
@@ -95,14 +95,8 @@ var terminalPullReasons = map[string]bool{
 	"ImagePullBackOff": true,
 }
 
-// terminalPullMessages are the registry responses that no amount of retrying
-// within a Helm timeout will fix: either the tag does not resolve, or — the case
-// that motivated this guard — the multi-arch index resolves but the per-platform
-// child manifest it references is absent.
-//
-// Deliberately narrow. Auth failures ("unauthorized", "pull access denied") are
-// excluded: they are already covered by the credential preflight, and treating
-// them as terminal here would abort deploys that a retry could still save.
+// terminalPullMessages are matched case-insensitively against the kubelet
+// waiting message.
 var terminalPullMessages = []string{
 	"not found",
 	"manifest unknown",
@@ -110,8 +104,7 @@ var terminalPullMessages = []string{
 }
 
 // terminalImagePullFailure reports whether a pod is blocked on an image the
-// registry will not serve. Init containers are inspected as well as app
-// containers: Camunda pods routinely fail in an init container first.
+// registry will not serve. Init and app container statuses are both inspected.
 func terminalImagePullFailure(pod *corev1.Pod) (*ImagePullFailure, bool) {
 	statuses := make([]corev1.ContainerStatus, 0,
 		len(pod.Status.InitContainerStatuses)+len(pod.Status.ContainerStatuses))
@@ -168,19 +161,15 @@ type imagePullGuard struct {
 }
 
 // startImagePullGuard derives a cancellable context for the Helm run and starts
-// watching pods in the release namespace. The returned context is cancelled as
-// soon as a terminal image pull failure is confirmed, which kills the helm child
-// process and ends the wait.
-//
-// The parent context is never cancelled: parallel scenario deploys and matrix
-// entries share one, so cancelling it would take down unrelated work.
+// watching pods in the release namespace. The returned context is cancelled once
+// a terminal image pull failure is confirmed, which kills the helm child process.
+// The parent context is left untouched.
 func startImagePullGuard(ctx context.Context, o types.Options) (context.Context, *imagePullGuard) {
 	guardCtx, cancel := context.WithCancel(ctx)
 	g := &imagePullGuard{cancel: cancel, done: make(chan struct{})}
 
 	lister, err := newPodLister(o.Kubeconfig, o.KubeContext)
 	if err != nil {
-		// Losing the guard must never fail a deploy that would otherwise work.
 		logging.Logger.Debug().Err(err).
 			Msg("Image pull guard disabled: could not build a Kubernetes client")
 		close(g.done)
@@ -215,8 +204,8 @@ func startImagePullGuard(ctx context.Context, o types.Options) (context.Context,
 	return guardCtx, g
 }
 
-// noopImagePullGuard returns a guard that watches nothing, so callers can treat
-// the disabled path exactly like the enabled one.
+// noopImagePullGuard returns a guard that watches nothing and reports no
+// failure.
 func noopImagePullGuard() *imagePullGuard {
 	g := &imagePullGuard{cancel: func() {}, done: make(chan struct{})}
 	close(g.done)
@@ -224,11 +213,8 @@ func noopImagePullGuard() *imagePullGuard {
 }
 
 // Stop shuts the guard down and reports the terminal failure it observed, if
-// any. It is idempotent and safe to call concurrently: context.CancelFunc
-// tolerates repeat calls, and receiving from an already-closed channel returns
-// immediately. Waiting on done unconditionally is what makes the returned value
-// reliable — an early return would let a second caller read failure before the
-// watcher has written it.
+// any. Idempotent and safe to call concurrently: cancel tolerates repeat calls,
+// and the unconditional receive on done orders every caller after the watcher.
 func (g *imagePullGuard) Stop() *ImagePullFailure {
 	g.cancel()
 	<-g.done
@@ -238,8 +224,7 @@ func (g *imagePullGuard) Stop() *ImagePullFailure {
 	return g.failure
 }
 
-// imagePullWatchDeps isolates the watcher from the clock and the cluster so the
-// poll loop is unit-testable without either.
+// imagePullWatchDeps isolates the watcher from the clock and the cluster.
 type imagePullWatchDeps struct {
 	list      func(ctx context.Context, namespace string) (*corev1.PodList, error)
 	sleep     func(ctx context.Context, d time.Duration) error
@@ -248,9 +233,8 @@ type imagePullWatchDeps struct {
 }
 
 // watchTerminalImagePull polls until the same terminal failure has been observed
-// threshold times in a row, or the context ends. Listing errors are ignored: the
-// namespace may not exist yet, and a transient API error must not be mistaken
-// for a healthy cluster or for a broken image.
+// threshold times in a row, or the context ends. A failed list neither confirms
+// nor clears a failure, so it resets the streak.
 func watchTerminalImagePull(ctx context.Context, deps imagePullWatchDeps, namespace string) *ImagePullFailure {
 	if namespace == "" {
 		return nil
@@ -270,6 +254,7 @@ func watchTerminalImagePull(ctx context.Context, deps imagePullWatchDeps, namesp
 
 		pods, err := deps.list(ctx, namespace)
 		if err != nil {
+			lastKey, streak = "", 0
 			continue
 		}
 
@@ -291,8 +276,7 @@ func watchTerminalImagePull(ctx context.Context, deps imagePullWatchDeps, namesp
 }
 
 // firstTerminalFailure returns the terminal failure of the alphabetically first
-// affected pod, so repeated polls of the same broken state agree on one pod
-// rather than alternating with map iteration order.
+// affected pod, keeping the streak key stable across polls.
 func firstTerminalFailure(pods *corev1.PodList) *ImagePullFailure {
 	var chosen *ImagePullFailure
 	for i := range pods.Items {

--- a/scripts/deploy-camunda/pkg/deployer/imagepull.go
+++ b/scripts/deploy-camunda/pkg/deployer/imagepull.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"scripts/camunda-core/pkg/kube"
+	"scripts/camunda-core/pkg/logging"
+	"scripts/deploy-camunda/pkg/types"
+)
+
+// An unresolvable image reference is not something `helm --wait` can recover
+// from: kubelet keeps retrying until the Helm timeout expires and the run ends
+// as "context deadline exceeded", which names neither the image nor the reason.
+// The guard below watches pods during the wait and aborts as soon as a pull
+// failure is provably terminal, turning a 20-minute timeout into a ~1-minute
+// failure that names the pod, container, image and registry error.
+//
+// It never turns a failing deploy into a passing one. It only shortens a deploy
+// that was already doomed, and replaces the diagnosis.
+
+const (
+	// imagePullGuardEnvVar disables the guard when set to "off" or "false", for
+	// the case where aborting early is worse than waiting out the timeout.
+	imagePullGuardEnvVar = "DEPLOY_CAMUNDA_IMAGE_PULL_GUARD"
+)
+
+// Vars rather than consts so tests can drive the poll loop without wall-clock
+// delay.
+var (
+	// imagePullGuardInterval is how often pods are polled during the wait.
+	imagePullGuardInterval = 15 * time.Second
+	// imagePullGuardThreshold is how many consecutive polls must report the same
+	// terminal failure before the wait is aborted. Two observations spaced by the
+	// interval rule out a snapshot taken mid-reconciliation, at a cost of one
+	// extra interval.
+	imagePullGuardThreshold = 2
+)
+
+// newPodLister builds the pod source used by the guard. It is a package-level
+// variable so tests can inject a fake without a cluster.
+var newPodLister = func(kubeconfig, kubeContext string) (podLister, error) {
+	return kube.NewClient(kubeconfig, kubeContext)
+}
+
+// podLister is the slice of the Kubernetes client the guard depends on.
+type podLister interface {
+	ListPods(ctx context.Context, namespace string) (*corev1.PodList, error)
+}
+
+// ImagePullFailure is a container image that the registry will not serve.
+type ImagePullFailure struct {
+	Pod       string
+	Container string
+	Image     string
+	// Reason is the kubelet waiting reason (ErrImagePull, ImagePullBackOff).
+	Reason string
+	// Message is the kubelet waiting message, which carries the registry error.
+	Message string
+}
+
+func (f *ImagePullFailure) Error() string {
+	return fmt.Sprintf(
+		"image %q for container %q in pod %q cannot be pulled and will not become available (%s): %s",
+		f.Image, f.Container, f.Pod, f.Reason, f.Message,
+	)
+}
+
+// terminalPullReasons are the kubelet waiting reasons that *may* denote an
+// unresolvable image. They are necessary but not sufficient — kubelet also uses
+// them for registry throttling and for auth failures — so a message match is
+// required as well.
+var terminalPullReasons = map[string]bool{
+	"ErrImagePull":     true,
+	"ImagePullBackOff": true,
+}
+
+// terminalPullMessages are the registry responses that no amount of retrying
+// within a Helm timeout will fix: either the tag does not resolve, or — the case
+// that motivated this guard — the multi-arch index resolves but the per-platform
+// child manifest it references is absent.
+//
+// Deliberately narrow. Auth failures ("unauthorized", "pull access denied") are
+// excluded: they are already covered by the credential preflight, and treating
+// them as terminal here would abort deploys that a retry could still save.
+var terminalPullMessages = []string{
+	"not found",
+	"manifest unknown",
+	"manifest_unknown",
+}
+
+// terminalImagePullFailure reports whether a pod is blocked on an image the
+// registry will not serve. Init containers are inspected as well as app
+// containers: Camunda pods routinely fail in an init container first.
+func terminalImagePullFailure(pod *corev1.Pod) (*ImagePullFailure, bool) {
+	statuses := make([]corev1.ContainerStatus, 0,
+		len(pod.Status.InitContainerStatuses)+len(pod.Status.ContainerStatuses))
+	statuses = append(statuses, pod.Status.InitContainerStatuses...)
+	statuses = append(statuses, pod.Status.ContainerStatuses...)
+
+	for _, cs := range statuses {
+		waiting := cs.State.Waiting
+		if waiting == nil || !terminalPullReasons[waiting.Reason] {
+			continue
+		}
+		if !matchesTerminalPullMessage(waiting.Message) {
+			continue
+		}
+		return &ImagePullFailure{
+			Pod:       pod.Name,
+			Container: cs.Name,
+			Image:     cs.Image,
+			Reason:    waiting.Reason,
+			Message:   strings.TrimSpace(waiting.Message),
+		}, true
+	}
+	return nil, false
+}
+
+func matchesTerminalPullMessage(message string) bool {
+	lower := strings.ToLower(message)
+	for _, m := range terminalPullMessages {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// imagePullGuardEnabled reports whether the guard should run.
+func imagePullGuardEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(imagePullGuardEnvVar))) {
+	case "off", "false", "0", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// imagePullGuard aborts an in-flight Helm wait when a pod hits a terminal image
+// pull failure.
+type imagePullGuard struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu      sync.Mutex
+	failure *ImagePullFailure
+	stopped bool
+}
+
+// startImagePullGuard derives a cancellable context for the Helm run and starts
+// watching pods in the release namespace. The returned context is cancelled as
+// soon as a terminal image pull failure is confirmed, which kills the helm child
+// process and ends the wait.
+//
+// The parent context is never cancelled: parallel scenario deploys and matrix
+// entries share one, so cancelling it would take down unrelated work.
+func startImagePullGuard(ctx context.Context, o types.Options) (context.Context, *imagePullGuard) {
+	guardCtx, cancel := context.WithCancel(ctx)
+	g := &imagePullGuard{cancel: cancel, done: make(chan struct{})}
+
+	lister, err := newPodLister(o.Kubeconfig, o.KubeContext)
+	if err != nil {
+		// Losing the guard must never fail a deploy that would otherwise work.
+		logging.Logger.Debug().Err(err).
+			Msg("Image pull guard disabled: could not build a Kubernetes client")
+		close(g.done)
+		return guardCtx, g
+	}
+
+	deps := imagePullWatchDeps{
+		list:      lister.ListPods,
+		sleep:     sleepCtx,
+		interval:  imagePullGuardInterval,
+		threshold: imagePullGuardThreshold,
+	}
+	go func() {
+		defer close(g.done)
+		failure := watchTerminalImagePull(guardCtx, deps, o.Namespace)
+		if failure == nil {
+			return
+		}
+		g.mu.Lock()
+		g.failure = failure
+		g.mu.Unlock()
+
+		logging.Logger.Error().
+			Str("pod", failure.Pod).
+			Str("container", failure.Container).
+			Str("image", failure.Image).
+			Str("reason", failure.Reason).
+			Msg("Aborting the Helm wait: image cannot be pulled")
+		cancel()
+	}()
+
+	return guardCtx, g
+}
+
+// noopImagePullGuard returns a guard that watches nothing, so callers can treat
+// the disabled path exactly like the enabled one.
+func noopImagePullGuard() *imagePullGuard {
+	g := &imagePullGuard{cancel: func() {}, done: make(chan struct{})}
+	close(g.done)
+	return g
+}
+
+// Stop shuts the guard down and reports the terminal failure it observed, if
+// any. It is idempotent and safe to call from a defer as well as inline.
+func (g *imagePullGuard) Stop() *ImagePullFailure {
+	g.mu.Lock()
+	alreadyStopped := g.stopped
+	g.stopped = true
+	g.mu.Unlock()
+
+	if !alreadyStopped {
+		g.cancel()
+		<-g.done
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.failure
+}
+
+// imagePullWatchDeps isolates the watcher from the clock and the cluster so the
+// poll loop is unit-testable without either.
+type imagePullWatchDeps struct {
+	list      func(ctx context.Context, namespace string) (*corev1.PodList, error)
+	sleep     func(ctx context.Context, d time.Duration) error
+	interval  time.Duration
+	threshold int
+}
+
+// watchTerminalImagePull polls until the same terminal failure has been observed
+// threshold times in a row, or the context ends. Listing errors are ignored: the
+// namespace may not exist yet, and a transient API error must not be mistaken
+// for a healthy cluster or for a broken image.
+func watchTerminalImagePull(ctx context.Context, deps imagePullWatchDeps, namespace string) *ImagePullFailure {
+	if namespace == "" {
+		return nil
+	}
+	threshold := deps.threshold
+	if threshold < 1 {
+		threshold = 1
+	}
+
+	var lastKey string
+	streak := 0
+
+	for {
+		if err := deps.sleep(ctx, deps.interval); err != nil {
+			return nil
+		}
+
+		pods, err := deps.list(ctx, namespace)
+		if err != nil {
+			continue
+		}
+
+		failure := firstTerminalFailure(pods)
+		if failure == nil {
+			lastKey, streak = "", 0
+			continue
+		}
+
+		key := failure.Pod + "/" + failure.Container + "/" + failure.Image
+		if key != lastKey {
+			lastKey, streak = key, 0
+		}
+		streak++
+		if streak >= threshold {
+			return failure
+		}
+	}
+}
+
+// firstTerminalFailure returns the terminal failure of the alphabetically first
+// affected pod, so repeated polls of the same broken state agree on one pod
+// rather than alternating with map iteration order.
+func firstTerminalFailure(pods *corev1.PodList) *ImagePullFailure {
+	var chosen *ImagePullFailure
+	for i := range pods.Items {
+		failure, ok := terminalImagePullFailure(&pods.Items[i])
+		if !ok {
+			continue
+		}
+		if chosen == nil || failure.Pod < chosen.Pod {
+			chosen = failure
+		}
+	}
+	return chosen
+}
+
+// sleepCtx waits for d, or returns early if the context ends.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/scripts/deploy-camunda/pkg/deployer/imagepull.go
+++ b/scripts/deploy-camunda/pkg/deployer/imagepull.go
@@ -29,19 +29,8 @@ import (
 	"scripts/deploy-camunda/pkg/types"
 )
 
-// An unresolvable image reference is not something `helm --wait` can recover
-// from: kubelet keeps retrying until the Helm timeout expires and the run ends
-// as "context deadline exceeded", which names neither the image nor the reason.
-// The guard below watches pods during the wait and aborts as soon as a pull
-// failure is provably terminal, turning a 20-minute timeout into a ~1-minute
-// failure that names the pod, container, image and registry error.
-//
-// It never turns a failing deploy into a passing one. It only shortens a deploy
-// that was already doomed, and replaces the diagnosis.
-
 const (
-	// imagePullGuardEnvVar disables the guard when set to "off" or "false", for
-	// the case where aborting early is worse than waiting out the timeout.
+	// imagePullGuardEnvVar disables the guard when set to "off", "false", "0" or "no".
 	imagePullGuardEnvVar = "DEPLOY_CAMUNDA_IMAGE_PULL_GUARD"
 )
 

--- a/scripts/deploy-camunda/pkg/deployer/imagepull.go
+++ b/scripts/deploy-camunda/pkg/deployer/imagepull.go
@@ -165,7 +165,6 @@ type imagePullGuard struct {
 
 	mu      sync.Mutex
 	failure *ImagePullFailure
-	stopped bool
 }
 
 // startImagePullGuard derives a cancellable context for the Helm run and starts
@@ -225,17 +224,14 @@ func noopImagePullGuard() *imagePullGuard {
 }
 
 // Stop shuts the guard down and reports the terminal failure it observed, if
-// any. It is idempotent and safe to call from a defer as well as inline.
+// any. It is idempotent and safe to call concurrently: context.CancelFunc
+// tolerates repeat calls, and receiving from an already-closed channel returns
+// immediately. Waiting on done unconditionally is what makes the returned value
+// reliable — an early return would let a second caller read failure before the
+// watcher has written it.
 func (g *imagePullGuard) Stop() *ImagePullFailure {
-	g.mu.Lock()
-	alreadyStopped := g.stopped
-	g.stopped = true
-	g.mu.Unlock()
-
-	if !alreadyStopped {
-		g.cancel()
-		<-g.done
-	}
+	g.cancel()
+	<-g.done
 
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/scripts/deploy-camunda/pkg/deployer/imagepull_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/imagepull_test.go
@@ -46,8 +46,7 @@ func waitingPod(name, container, image, reason, message string, init bool) corev
 	return pod
 }
 
-// The message containerd emitted during the 2026-08-19 incident: the multi-arch
-// index resolved, its amd64 child did not.
+// Verbatim kubelet message from job 96141556284.
 const childManifest404 = `rpc error: code = NotFound desc = failed to pull and unpack image ` +
 	`"registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17": failed to copy: ` +
 	`httpReadSeeker: failed open: content at https://registry.camunda.cloud/v2/vendor-ee/postgresql/` +
@@ -81,9 +80,6 @@ func TestTerminalImagePullFailure(t *testing.T) {
 			wantCtr: "wait-for-es",
 		},
 		{
-			// Auth failures are recoverable by fixing a secret and are already
-			// covered by the credential preflight; aborting on them would kill
-			// deploys a retry could save.
 			name:    "unauthorized is not terminal",
 			pod:     waitingPod("p", "c", "reg/i:1", "ErrImagePull", "unauthorized: authentication required", false),
 			wantHit: false,
@@ -214,6 +210,24 @@ func TestWatchTerminalImagePull(t *testing.T) {
 		}
 	})
 
+	t.Run("a listing error breaks the streak", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		deps := imagePullWatchDeps{
+			list: func(context.Context, string) (*corev1.PodList, error) {
+				calls++
+				if calls == 2 {
+					return nil, errors.New("api server timeout")
+				}
+				return podList(broken), nil
+			},
+			sleep: noSleep(3), threshold: 2,
+		}
+		if got := watchTerminalImagePull(context.Background(), deps, "ns"); got != nil {
+			t.Fatalf("observations either side of a blind poll are not consecutive, got %v", got)
+		}
+	})
+
 	t.Run("empty namespace is a no-op", func(t *testing.T) {
 		t.Parallel()
 		deps := imagePullWatchDeps{
@@ -231,9 +245,8 @@ type fakeLister struct{ pods *corev1.PodList }
 
 func (f fakeLister) ListPods(context.Context, string) (*corev1.PodList, error) { return f.pods, nil }
 
-// TestUpgradeInstall_AbortsOnTerminalImagePull is the end-to-end assertion: a
-// broken image must end the Helm wait rather than run it to timeout, and the
-// resulting error must name the image instead of reporting "signal: killed".
+// TestUpgradeInstall_AbortsOnTerminalImagePull asserts the wait ends early and
+// the error names the image rather than the killed process.
 func TestUpgradeInstall_AbortsOnTerminalImagePull(t *testing.T) {
 	broken := waitingPod("integration-postgresql-0", "postgresql",
 		"registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17",
@@ -256,7 +269,6 @@ func TestUpgradeInstall_AbortsOnTerminalImagePull(t *testing.T) {
 	)
 	defer restore()
 
-	// Stand in for `helm --wait` burning its timeout: block until cancelled.
 	helmRunCapturing = func(ctx context.Context, args []string, workDir string) (string, error) {
 		select {
 		case <-ctx.Done():
@@ -297,8 +309,8 @@ func TestUpgradeInstall_AbortsOnTerminalImagePull(t *testing.T) {
 	}
 }
 
-// TestUpgradeInstall_NoGuardWhenNotWaiting proves the guard never runs (and so
-// never builds a client or polls) for a non-waiting install.
+// TestUpgradeInstall_NoGuardWhenNotWaiting asserts no client is built when the
+// install does not wait.
 func TestUpgradeInstall_NoGuardWhenNotWaiting(t *testing.T) {
 	origLister := newPodLister
 	newPodLister = func(string, string) (podLister, error) {
@@ -324,7 +336,6 @@ func TestUpgradeInstall_NoGuardWhenNotWaiting(t *testing.T) {
 	}
 }
 
-// TestImagePullGuardDisabledByEnv covers the escape hatch.
 func TestImagePullGuardDisabledByEnv(t *testing.T) {
 	for _, v := range []string{"off", "false", "0", "no", "OFF"} {
 		t.Setenv(imagePullGuardEnvVar, v)

--- a/scripts/deploy-camunda/pkg/deployer/imagepull_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/imagepull_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"scripts/deploy-camunda/pkg/types"
+)
+
+// waitingPod builds a pod whose named container is stuck in Waiting.
+func waitingPod(name, container, image, reason, message string, init bool) corev1.Pod {
+	status := corev1.ContainerStatus{
+		Name:  container,
+		Image: image,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: reason, Message: message},
+		},
+	}
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if init {
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{status}
+	} else {
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{status}
+	}
+	return pod
+}
+
+// The message containerd emitted during the 2026-08-19 incident: the multi-arch
+// index resolved, its amd64 child did not.
+const childManifest404 = `rpc error: code = NotFound desc = failed to pull and unpack image ` +
+	`"registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17": failed to copy: ` +
+	`httpReadSeeker: failed open: content at https://registry.camunda.cloud/v2/vendor-ee/postgresql/` +
+	`manifests/sha256:1a9ef74da62314cdc642c7d9635f50c6a00fd96241172ed35c0b2867c4d51bb8 not found: not found`
+
+func TestTerminalImagePullFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pod     corev1.Pod
+		wantHit bool
+		wantCtr string
+	}{
+		{
+			name:    "missing child manifest is terminal",
+			pod:     waitingPod("integration-postgresql-0", "postgresql", "reg/postgresql:15", "ImagePullBackOff", childManifest404, false),
+			wantHit: true,
+			wantCtr: "postgresql",
+		},
+		{
+			name:    "ErrImagePull with manifest unknown is terminal",
+			pod:     waitingPod("p", "c", "reg/i:1", "ErrImagePull", "manifest unknown: manifest unknown", false),
+			wantHit: true,
+			wantCtr: "c",
+		},
+		{
+			name:    "init container is inspected too",
+			pod:     waitingPod("p", "wait-for-es", "reg/os-shell:12", "ImagePullBackOff", childManifest404, true),
+			wantHit: true,
+			wantCtr: "wait-for-es",
+		},
+		{
+			// Auth failures are recoverable by fixing a secret and are already
+			// covered by the credential preflight; aborting on them would kill
+			// deploys a retry could save.
+			name:    "unauthorized is not terminal",
+			pod:     waitingPod("p", "c", "reg/i:1", "ErrImagePull", "unauthorized: authentication required", false),
+			wantHit: false,
+		},
+		{
+			name:    "throttled pull is not terminal",
+			pod:     waitingPod("p", "c", "reg/i:1", "ErrImagePull", "toomanyrequests: rate limit exceeded", false),
+			wantHit: false,
+		},
+		{
+			name:    "unrelated waiting reason is ignored",
+			pod:     waitingPod("p", "c", "reg/i:1", "CrashLoopBackOff", "back-off restarting failed container", false),
+			wantHit: false,
+		},
+		{
+			name:    "running pod is ignored",
+			pod:     corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}},
+			wantHit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := terminalImagePullFailure(&tt.pod)
+			if ok != tt.wantHit {
+				t.Fatalf("terminalImagePullFailure() ok = %v, want %v", ok, tt.wantHit)
+			}
+			if !tt.wantHit {
+				return
+			}
+			if got.Container != tt.wantCtr {
+				t.Errorf("container = %q, want %q", got.Container, tt.wantCtr)
+			}
+			if got.Pod != tt.pod.Name {
+				t.Errorf("pod = %q, want %q", got.Pod, tt.pod.Name)
+			}
+		})
+	}
+}
+
+func TestImagePullFailureErrorNamesEverything(t *testing.T) {
+	t.Parallel()
+	f := &ImagePullFailure{
+		Pod: "integration-postgresql-0", Container: "postgresql",
+		Image:  "registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17",
+		Reason: "ImagePullBackOff", Message: childManifest404,
+	}
+	msg := f.Error()
+	for _, want := range []string{f.Pod, f.Container, f.Image, f.Reason, "not found"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+// noSleep runs the poll loop without wall-clock delay, and ends it after
+// maxTicks so a test can never hang.
+func noSleep(maxTicks int) func(context.Context, time.Duration) error {
+	ticks := 0
+	return func(ctx context.Context, _ time.Duration) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		ticks++
+		if ticks > maxTicks {
+			return errors.New("tick budget exhausted")
+		}
+		return nil
+	}
+}
+
+func podList(pods ...corev1.Pod) *corev1.PodList { return &corev1.PodList{Items: pods} }
+
+func TestWatchTerminalImagePull(t *testing.T) {
+	t.Parallel()
+
+	broken := waitingPod("integration-postgresql-0", "postgresql", "reg/pg:15", "ImagePullBackOff", childManifest404, false)
+	healthy := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "integration-postgresql-0"}}
+
+	t.Run("fires once the threshold is met", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		deps := imagePullWatchDeps{
+			list: func(context.Context, string) (*corev1.PodList, error) {
+				calls++
+				return podList(broken), nil
+			},
+			sleep: noSleep(10), threshold: 2,
+		}
+		got := watchTerminalImagePull(context.Background(), deps, "ns")
+		if got == nil {
+			t.Fatal("expected a failure, got nil")
+		}
+		if calls != 2 {
+			t.Errorf("expected to abort on the 2nd confirmation, got %d polls", calls)
+		}
+	})
+
+	t.Run("a single observation is not enough", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		deps := imagePullWatchDeps{
+			list: func(context.Context, string) (*corev1.PodList, error) {
+				calls++
+				if calls == 1 {
+					return podList(broken), nil
+				}
+				return podList(healthy), nil
+			},
+			sleep: noSleep(4), threshold: 2,
+		}
+		if got := watchTerminalImagePull(context.Background(), deps, "ns"); got != nil {
+			t.Fatalf("expected no abort after the state recovered, got %v", got)
+		}
+	})
+
+	t.Run("listing errors do not abort", func(t *testing.T) {
+		t.Parallel()
+		deps := imagePullWatchDeps{
+			list: func(context.Context, string) (*corev1.PodList, error) {
+				return nil, errors.New("namespace not found")
+			},
+			sleep: noSleep(3), threshold: 2,
+		}
+		if got := watchTerminalImagePull(context.Background(), deps, "ns"); got != nil {
+			t.Fatalf("a transient API error must not be read as an image failure, got %v", got)
+		}
+	})
+
+	t.Run("empty namespace is a no-op", func(t *testing.T) {
+		t.Parallel()
+		deps := imagePullWatchDeps{
+			list:  func(context.Context, string) (*corev1.PodList, error) { t.Fatal("must not poll"); return nil, nil },
+			sleep: noSleep(1), threshold: 1,
+		}
+		if got := watchTerminalImagePull(context.Background(), deps, ""); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+}
+
+// fakeLister satisfies podLister.
+type fakeLister struct{ pods *corev1.PodList }
+
+func (f fakeLister) ListPods(context.Context, string) (*corev1.PodList, error) { return f.pods, nil }
+
+// TestUpgradeInstall_AbortsOnTerminalImagePull is the end-to-end assertion: a
+// broken image must end the Helm wait rather than run it to timeout, and the
+// resulting error must name the image instead of reporting "signal: killed".
+func TestUpgradeInstall_AbortsOnTerminalImagePull(t *testing.T) {
+	broken := waitingPod("integration-postgresql-0", "postgresql",
+		"registry.camunda.cloud/vendor-ee/postgresql:15.18.0-debian-12-r17",
+		"ImagePullBackOff", childManifest404, false)
+
+	origLister := newPodLister
+	newPodLister = func(string, string) (podLister, error) {
+		return fakeLister{pods: podList(broken)}, nil
+	}
+	defer func() { newPodLister = origLister }()
+
+	origInterval := imagePullGuardInterval
+	imagePullGuardInterval = time.Millisecond
+	defer func() { imagePullGuardInterval = origInterval }()
+
+	restore := stubHelm(
+		func(ctx context.Context, args []string, workDir string) error { return nil },
+		func(ctx context.Context, name, url string) error { return nil },
+		func(ctx context.Context) error { return nil },
+	)
+	defer restore()
+
+	// Stand in for `helm --wait` burning its timeout: block until cancelled.
+	helmRunCapturing = func(ctx context.Context, args []string, workDir string) (string, error) {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("signal: killed")
+		case <-time.After(10 * time.Second):
+			return "", fmt.Errorf("test timed out: the guard never cancelled the wait")
+		}
+	}
+
+	err := upgradeInstall(context.Background(), types.Options{
+		ReleaseName: "integration",
+		ChartPath:   "/charts/camunda-platform-8.7",
+		Namespace:   "ns",
+		Wait:        true,
+		Timeout:     20 * time.Minute,
+	})
+	if err == nil {
+		t.Fatal("expected the install to fail")
+	}
+
+	var helmErr *HelmError
+	if !errors.As(err, &helmErr) {
+		t.Fatalf("expected a *HelmError so matrix logging keeps working, got %T", err)
+	}
+	if !strings.Contains(helmErr.Reason, "unresolvable container image") {
+		t.Errorf("reason should name the real cause, got %q", helmErr.Reason)
+	}
+
+	var pullErr *ImagePullFailure
+	if !errors.As(err, &pullErr) {
+		t.Fatalf("expected the cause to be an *ImagePullFailure, got %v", helmErr.Cause)
+	}
+	if !strings.Contains(err.Error(), "vendor-ee/postgresql") {
+		t.Errorf("error should name the image, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "signal: killed") {
+		t.Errorf("the killed-process error must not leak to the user, got %q", err.Error())
+	}
+}
+
+// TestUpgradeInstall_NoGuardWhenNotWaiting proves the guard never runs (and so
+// never builds a client or polls) for a non-waiting install.
+func TestUpgradeInstall_NoGuardWhenNotWaiting(t *testing.T) {
+	origLister := newPodLister
+	newPodLister = func(string, string) (podLister, error) {
+		t.Fatal("guard must not start when the install does not wait")
+		return nil, nil
+	}
+	defer func() { newPodLister = origLister }()
+
+	restore := stubHelm(
+		func(ctx context.Context, args []string, workDir string) error { return nil },
+		func(ctx context.Context, name, url string) error { return nil },
+		func(ctx context.Context) error { return nil },
+	)
+	defer restore()
+
+	if err := upgradeInstall(context.Background(), types.Options{
+		ReleaseName: "integration",
+		ChartPath:   "/charts/camunda-platform-8.7",
+		Namespace:   "ns",
+		Wait:        false,
+	}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+// TestImagePullGuardDisabledByEnv covers the escape hatch.
+func TestImagePullGuardDisabledByEnv(t *testing.T) {
+	for _, v := range []string{"off", "false", "0", "no", "OFF"} {
+		t.Setenv(imagePullGuardEnvVar, v)
+		if imagePullGuardEnabled() {
+			t.Errorf("%s=%q should disable the guard", imagePullGuardEnvVar, v)
+		}
+	}
+	for _, v := range []string{"", "on", "true", "anything"} {
+		t.Setenv(imagePullGuardEnvVar, v)
+		if !imagePullGuardEnabled() {
+			t.Errorf("%s=%q should leave the guard enabled", imagePullGuardEnvVar, v)
+		}
+	}
+}
+
+func TestNoopGuardStopIsSafe(t *testing.T) {
+	t.Parallel()
+	g := noopImagePullGuard()
+	if got := g.Stop(); got != nil {
+		t.Fatalf("noop guard must report no failure, got %v", got)
+	}
+	if got := g.Stop(); got != nil {
+		t.Fatalf("Stop must be idempotent, got %v", got)
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up cleanup on the code added by #6924. No behaviour change.

It could not be pushed onto that branch because the PR was already in the merge queue, so it is
stacked on it. The base moves to `main` once #6924 lands.

Related to #6921.

### What's in this PR?

Three structural findings from a review pass over `enterprise_images.go`, plus one comment removal
required by `AGENTS.md`.

**The worker pool was reimplementing `errgroup`.** `golang.org/x/sync` is already a direct dependency
of `scripts/deploy-camunda`, so the semaphore channel, the `WaitGroup` and the index-passing closure
had a canonical equivalent in `errgroup.Group` with `SetLimit`. The module is on `go 1.25.0`, which
gives per-iteration loop variables, so the closure does not need arguments either. Same bounded
concurrency, same input-order results, fifteen fewer lines of bookkeeping.

**`checkedImage` was a copy of `imageResolution`.** It carried the same four concepts plus the source
layer, and existed only so the resolution loop could copy two error fields into a second struct.
`imageResolution` gains a `Source` field and is returned directly.

**A dead default.** `checkPinnedImages` fell back to `defaultImagePlatform` on an empty `platform`,
but its only caller passes that constant explicitly and every test passes `"linux/amd64"`, so the
branch was unreachable.

**The narration comment block in `imagepull.go` is removed.** `AGENTS.md` rules out reasoning and
narration comments: comments explain only non-obvious HOW, and tactical rationale belongs in the PR
body or the commit message. The rationale it carried lives in #6924 and #6804.

What stays on both files is the non-obvious HOW a reader cannot derive from the code: why a kubelet
reason alone is not sufficient and a message match is also required, why two consecutive observations
are needed rather than one, why only string scalars are accepted for a tag (an unquoted `tag: 8.10`
arrives as `float64(8.1)` and its original text is unrecoverable), and why a colon before the last
slash is a registry port rather than a tag separator.

Verified with `go build`, `go vet`, `go test` and `go test -race` on `deploy` and `pkg/deployer`. The
existing tests cover the refactored paths unchanged, which is the point: no test needed editing.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
