### PR TITLE
ci: add scoped Renovate lock file maintenance for the npm workspaces

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,6 +48,15 @@
     addLabels: ['security'],
     enabled: true,
   },
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ['before 5am on the first day of the month'],
+    groupName: 'npm lockfiles',
+    automerge: false,
+    platformAutomerge: false,
+    recreateWhen: 'auto',
+    addLabels: ['deps/tools', 'kind/chore'],
+  },
   'helm-values': {
     fileMatch: [
       '(^|/).*?values.*?\\.yaml$',
@@ -408,6 +417,20 @@
         'charts/camunda-platform-8.5/**',
         'charts/camunda-platform-8.6/**',
       ],
+    },
+    {
+      description: 'Disable lock file maintenance for all managers.',
+      matchUpdateTypes: ['lockFileMaintenance'],
+      enabled: false,
+    },
+    {
+      description: 'Enable lock file maintenance for the npm workspaces.',
+      matchUpdateTypes: ['lockFileMaintenance'],
+      matchFileNames: [
+        'helm-docs-site/**',
+        'helm-values-mcp/**',
+      ],
+      enabled: true,
     },
   ],
   customManagers: [


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6784.

There are 130 open Dependabot alerts on `main` (2 critical, 42 high, 74 medium, 12 low), all transitive npm findings in `helm-docs-site/package-lock.json` (73) and `helm-values-mcp/package-lock.json` (57).

Renovate detects both npm manifests (dependency dashboard #39 lists `npm (2)`) and updates their direct dependencies reliably. Nothing re-resolves the transitive graph, so the lockfiles freeze at whatever npm picked when they were last written. `npm ci`, which is what CI runs, never re-resolves, so CI stays green while the lockfiles rot. GitHub's Dependabot security updates are also off (`automated-security-fixes` returns `{"enabled": false}`) and there is no `.github/dependabot.yml`, so no remediation mechanism exists on either side.

### What's in this PR?

Enables Renovate `lockFileMaintenance`, scoped to the two npm workspaces.

`lockFileMaintenance` is a top-level-only option — it is not a valid key inside a `packageRules` entry (absent from `packageRules.items.properties` in `renovate-schema.json`). Nesting it in a rule passes `renovate-config-validator` but is a silent no-op. Scoping is therefore expressed as two `matchUpdateTypes: ['lockFileMaintenance']` rules: disable for all managers, then re-enable for `helm-docs-site/**` and `helm-values-mcp/**`. Later matching rule wins, so these two must remain last and in that order.

Monthly, grouped into one PR, no automerge. `minimumReleaseAge` is deliberately not set: it gates a dependency update and needs a datasource with a release timestamp, and lock file maintenance has neither — Renovate deletes the lockfile and lets npm choose versions. The refresh is gated by review plus the existing path-filtered CI (`make mcp.deps` / `mcp.build` / `mcp.test`, and `npm ci` + `npm run build` for the docs site).

Verified with the repo-pinned toolchain (nodejs 24.19.0, npm 11.17.0) in disposable directories; no lockfile is committed here.

| | before | after refresh |
|---|---|---|
| `helm-values-mcp` production (`--omit=dev`) | 9 (5 high) | 0 |
| `helm-values-mcp` total | 14 (10 high) | 0 |
| `helm-docs-site` total | 54 (2 critical, 36 high) | 25 (0 critical, 19 high) |

`helm-values-mcp` on the refreshed lockfile: `npm ci` clean, `tsc` clean, 31/31 tests pass. The refresh moves transitive majors — `@hono/node-server` 1.19.9 → 2.1.1 (permitted by the MCP SDK's `^1.19.9 || ^2.0.5`) and `vite` 7.3.1 → 8.2.2 — which is why automerge is off.

Dry run (`renovate --platform=local --dry-run=full`, schedule forced to `at any time`): 33 flattened updates / 7 branches with one `renovate/lock-file-maintenance-npm-lockfiles`, against a 31 / 6 baseline without the option. Exactly the two npm workspaces. Renovate detects 21 `gomod` packageFiles in this repo and gomod is itself lock-file-maintenance-capable; none were selected. No `Chart.lock` is tracked, and the only tracked `package-lock.json` files are the two intended ones.

Residual `helm-docs-site` findings, which this cannot close:

- `image-size` — advisory range is `*`; no patched version exists at any version. `@docusaurus/mdx-loader@3.10.2` requires `^2.0.2` and 2.0.2 is the latest publish. Accounts for the bulk of the 19 residual highs.
- `serialize-javascript` — advisory `<=7.0.4`; 7.1.0 is published but blocked two levels up, as `@docusaurus/bundler@3.10.2` pins `copy-webpack-plugin ^11.0.0` (wants `^6.0.0`) and `css-minimizer-webpack-plugin ^5.0.1` (wants `^6.0.1`). The plugin releases accepting `^7.0.3` are `copy-webpack-plugin@14` / `css-minimizer-webpack-plugin@8`, both majors outside Docusaurus's ranges.

This is upstream lag, not a pin here: 3.10.2 is the latest published Docusaurus, and the exact-version style in `helm-docs-site/package.json` is Docusaurus's lockstep-monorepo convention that Renovate already keeps current. Both advisories are build-time-only DoS / CPU-exhaustion in a static-site generator. An `overrides` entry forcing `serialize-javascript ^7.1.0` was measured — it resolves and still builds, but closes only 1 high and 3 moderate (25 → 21) while running two webpack plugins against a major they do not declare, so it is not included.

Per the issue's acceptance criteria, the lockfile refresh itself is left to the generated maintenance PR.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
