### PR TITLE
test(8.10): temporarily disable E2E tests for mns scenarios

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -1735,6 +1735,7 @@ integration:
           tier: 2
           infra-type:
             gke: distroci
+          skip-e2e: true
           post-deploy:
             script: post-deploy-hub-ping.sh
             description: |
@@ -1778,6 +1779,7 @@ integration:
           tier: 2
           infra-type:
             gke: distroci
+          skip-e2e: true
           topology:
             name: hub-2orch
             releases:

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/multinamespace-2orch.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/multinamespace-2orch.yaml
@@ -4,6 +4,7 @@ flows:
   - install
 platforms:
   - gke
+skip-e2e: true
 infra-type:
   gke: distroci
 topology:

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/multinamespace.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/multinamespace.yaml
@@ -5,6 +5,7 @@ flows:
 post-deploy: hub-ping
 platforms:
   - gke
+skip-e2e: true
 infra-type:
   gke: distroci
 topology:


### PR DESCRIPTION
### Which problem does the PR fix?

The `mns` and `mns2` topology smoke tests repeatedly fail in the merge-group matrix and block unrelated PRs. Recent examples:

- https://github.com/camunda/camunda-platform-helm/actions/runs/33076990587
- https://github.com/camunda/camunda-platform-helm/actions/runs/33076989121
- https://github.com/camunda/camunda-platform-helm/actions/runs/33071502993

The deployments succeed. Only the Playwright topology smoke jobs fail. #6909 tracks the test failure, and #6964 tracks restoring this coverage.

### What's in this PR?

Sets `skip-e2e: true` for the `multinamespace` and `multinamespace-2orch` scenarios and regenerates the registry snapshot. Both tier-2 scenario deployments remain enabled; only their E2E jobs are skipped.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
