### PR TITLE
ci: check out the merge ref instead of the pull request head in chart-version CI

### DIFF
--- a/.github/actions/setup-deploy-camunda/action.yaml
+++ b/.github/actions/setup-deploy-camunda/action.yaml
@@ -48,3 +48,21 @@ runs:
         else
           echo "$GITHUB_WORKSPACE/.local-bin" >> "$GITHUB_PATH"
         fi
+    - name: Report selected deploy-camunda
+      shell: bash
+      env:
+        DC_RUNNER_BINARY: ${{ steps.runner-binary.outputs.present }}
+        DC_CACHED_BINARY: ${{ steps.binary-check.outputs.present }}
+      run: |
+        if [[ "${DC_RUNNER_BINARY}" == "true" ]]; then
+          binary_source="runner-temp"
+        elif [[ "${DC_CACHED_BINARY}" == "true" ]]; then
+          binary_source="cache"
+        else
+          binary_source="build"
+        fi
+        echo "::group::deploy-camunda selection"
+        echo "source:    ${binary_source}"
+        echo "path:      $(command -v deploy-camunda)"
+        deploy-camunda version || echo "revision:  unavailable"
+        echo "::endgroup::"

--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -223,8 +223,8 @@ jobs:
       ingress-ready-timeout: ${{ inputs.ingress-ready-timeout }}
       flows: ${{ inputs.flows }}
       camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"
-      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
-      caller-git-ref: "${{ github.event.pull_request.head.sha }}"
+      camunda-helm-git-ref: "${{ github.sha }}"
+      caller-git-ref: "${{ github.sha }}"
       test-case: "${{ inputs.case }}"
       scenario: "${{ inputs.scenario }}"
       e2e-enabled: "${{ inputs.e2e-enabled }}"

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -237,7 +237,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number || github.ref }}-unit-${{ matrix.version }}"
       camunda-helm-dir: "camunda-platform-${{ matrix.version }}"
-      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
+      camunda-helm-git-ref: "${{ github.sha }}"
 
   validation:
     if: ${{ needs.init.outputs.camunda-versions != '[]' }}
@@ -251,7 +251,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number || github.ref }}-vald-${{ matrix.version }}"
       camunda-helm-dir: "camunda-platform-${{ matrix.version }}"
-      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
+      camunda-helm-git-ref: "${{ github.sha }}"
 
   kind-testing:
     if: ${{ needs.init.outputs.camunda-versions != '[]' && !contains(github.head_ref, 'release-please--branches--') }}
@@ -269,7 +269,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number || github.ref }}-loc-${{ matrix.version }}"
       camunda-helm-dir: "camunda-platform-${{ matrix.version }}"
-      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
+      camunda-helm-git-ref: "${{ github.sha }}"
 
   integration-tests:
     # Skip integration tests for Renovate image/digest PRs - these images are already

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -318,7 +318,7 @@ jobs:
           CI_PLATFORMS: "${{ inputs.platforms }}"
           CI_FLOWS: "${{ inputs.flows }}"
         run: |
-          "$GITHUB_WORKSPACE/.local-bin/deploy-camunda" ci integration-matrix \
+          deploy-camunda ci integration-matrix \
             --platforms "$CI_PLATFORMS" \
             --flows "$CI_FLOWS" \
             --matrix-data "$CI_MATRIX_INPUT"
@@ -329,7 +329,7 @@ jobs:
           CI_SHORTNAME: "${{ inputs.shortname }}"
           CI_SCENARIO: "${{ inputs.scenario }}"
         run: |
-          "$GITHUB_WORKSPACE/.local-bin/deploy-camunda" ci e2e-matrix \
+          deploy-camunda ci e2e-matrix \
             --repo-root "$GITHUB_WORKSPACE" \
             --chart-dir "$CI_CHART_DIR" \
             --shortname "$CI_SHORTNAME" \

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -111,6 +111,9 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "diagnostics" || (cmd.Parent() != nil && cmd.Parent().Name() == "diagnostics") {
 					return nil
 				}
+				if cmd.Name() == "version" {
+					return nil
+				}
 				// ci subcommands compute GitHub Actions step variables; no
 				// chart/namespace config needed.
 				if cmd.Name() == "ci" || (cmd.Parent() != nil && cmd.Parent().Name() == "ci") {
@@ -590,6 +593,7 @@ func Execute() error {
 	rootCmd.AddCommand(newCICommand())
 	rootCmd.AddCommand(newE2EEnvCommand())
 	rootCmd.AddCommand(newTopologyCommand())
+	rootCmd.AddCommand(newVersionCommand())
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/scripts/deploy-camunda/cmd/version.go
+++ b/scripts/deploy-camunda/cmd/version.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+const unknownBuildValue = "unknown"
+
+type buildStamp struct {
+	Revision  string
+	Committed string
+	Modified  string
+	GoVersion string
+}
+
+func readBuildStamp() buildStamp {
+	stamp := buildStamp{
+		Revision:  unknownBuildValue,
+		Committed: unknownBuildValue,
+		Modified:  unknownBuildValue,
+		GoVersion: unknownBuildValue,
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return stamp
+	}
+	if info.GoVersion != "" {
+		stamp.GoVersion = info.GoVersion
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			stamp.Revision = setting.Value
+		case "vcs.time":
+			stamp.Committed = setting.Value
+		case "vcs.modified":
+			stamp.Modified = setting.Value
+		}
+	}
+	return stamp
+}
+
+func (s buildStamp) write(w io.Writer) {
+	fmt.Fprintf(w, "revision:  %s\n", s.Revision)
+	fmt.Fprintf(w, "committed: %s\n", s.Committed)
+	fmt.Fprintf(w, "modified:  %s\n", s.Modified)
+	fmt.Fprintf(w, "go:        %s\n", s.GoVersion)
+}
+
+func newVersionCommand() *cobra.Command {
+	var short bool
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the source revision this binary was built from",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			stamp := readBuildStamp()
+			out := cmd.OutOrStdout()
+			if short {
+				fmt.Fprintln(out, stamp.Revision)
+				return nil
+			}
+			stamp.write(out)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&short, "short", false, "Print only the source revision")
+	return cmd
+}

--- a/scripts/deploy-camunda/cmd/version_test.go
+++ b/scripts/deploy-camunda/cmd/version_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionCommandOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		contains []string
+		lines    int
+	}{
+		{
+			name:     "full stamp",
+			args:     nil,
+			contains: []string{"revision:", "committed:", "modified:", "go:"},
+			lines:    4,
+		},
+		{
+			name:     "short prints revision only",
+			args:     []string{"--short"},
+			contains: nil,
+			lines:    1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newVersionCommand()
+			out := &bytes.Buffer{}
+			cmd.SetOut(out)
+			cmd.SetErr(out)
+			cmd.SetArgs(tc.args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("version command failed: %v", err)
+			}
+
+			got := out.String()
+			for _, want := range tc.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q:\n%s", want, got)
+				}
+			}
+			lines := strings.Split(strings.TrimSpace(got), "\n")
+			if len(lines) != tc.lines {
+				t.Errorf("expected %d line(s), got %d:\n%s", tc.lines, len(lines), got)
+			}
+			for _, line := range lines {
+				if strings.TrimSpace(line) == "" {
+					t.Errorf("empty line in output:\n%s", got)
+				}
+			}
+		})
+	}
+}
+
+func TestReadBuildStampNeverEmpty(t *testing.T) {
+	stamp := readBuildStamp()
+	fields := map[string]string{
+		"revision":  stamp.Revision,
+		"committed": stamp.Committed,
+		"modified":  stamp.Modified,
+		"go":        stamp.GoVersion,
+	}
+	for name, value := range fields {
+		if value == "" {
+			t.Errorf("%s is empty; expected a value or %q", name, unknownBuildValue)
+		}
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6853.

### What's in this PR?

For a `pull_request` event GitHub loads reusable workflows from `refs/pull/N/merge` (PR merged into `main`), but the chart-version jobs checked out `github.event.pull_request.head.sha`. A branch behind `main` therefore ran new workflow steps against old `scripts/` source. On #6788 that surfaced as `Error: unknown flag: --platforms` across 15 `Generate test matrix - gke` jobs, after #6610 added `deploy-camunda ci integration-matrix` to `main`.

- `camunda-helm-git-ref` / `caller-git-ref` now use `${{ github.sha }}`, so the source tree matches the workflow YAML. On `merge_group`, `workflow_dispatch` and `push`, `github.sha` resolves to what the previous empty-string fallback already produced. `pr-head-sha`, which feeds commit statuses, still uses the PR head.
- `test-integration-template.yaml` calls `deploy-camunda` from `PATH` instead of hardcoding `$GITHUB_WORKSPACE/.local-bin/deploy-camunda`, matching `workflow-vars`, `test-type-vars` and `generate-chart-matrix`. The hardcoded path breaks if `setup-deploy-camunda` resolves the binary from `$RUNNER_TEMP/bin`.
- New `deploy-camunda version` (and `--short`) reads the VCS stamp `go build -buildvcs` embeds, so a binary can report the revision it was built from.
- `setup-deploy-camunda` logs the selection — source (`runner-temp` / `cache` / `build`), resolved path, and revision — so a future mismatch is one line in the job log.

Verification: `go vet` clean; `go test ./cmd/ ./matrix/` pass; `make go.fmt` a no-op; `shellcheck` clean on the new step; `actionlint` output on the changed workflows byte-identical to `main`. VCS stamping confirmed under `CGO_ENABLED=0` for the nested module. The original failure reproduces locally from the #6788 head source and does not reproduce from current source.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
