### PR TITLE
test(8.10): share one elasticsearch across remaining upgrade-minor scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ go.addlicense-install:
 # surfaces as an error instead of a vacuous pass.
 .PHONY: go.addlicense-files
 go.addlicense-files:
-	@files=$$(find $(chartPath)/test -name '*.go' 2>/dev/null | grep -Ev '$(licenseExcludeGrep)'); \
+	@files=$$(find $(chartPath)/test -name '*.go' -not -path '*/node_modules/*' 2>/dev/null | grep -Ev '$(licenseExcludeGrep)'); \
 	if [ -z "$$files" ]; then \
 		echo "ERROR: no in-scope .go files under '$(chartPath)/test' - refusing to report success." >&2; \
 		echo "       (excluded from the licence gate: $(licenseExcludePaths))" >&2; \

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -317,7 +317,7 @@ integration:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
         - name: keycloak-rba
-          enabled: false
+          enabled: true
           shortname: kerba
           auth: keycloak
           flow: upgrade-minor

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -359,7 +359,7 @@ integration:
             eks: preemptible
             gke: distroci
           identity: keycloak
-          persistence: elasticsearch
+          persistence: elasticsearch-companion
           dependencies:
             - chart: charts/internal-keycloak-26
               release-name: keycloak
@@ -886,7 +886,7 @@ integration:
             eks: preemptible
             gke: distroci
           identity: keycloak
-          persistence: elasticsearch
+          persistence: elasticsearch-companion
           features:
             - hub-webmodeler-only
           skip-e2e: true
@@ -919,7 +919,7 @@ integration:
             eks: preemptible
             gke: distroci
           identity: keycloak
-          persistence: elasticsearch
+          persistence: elasticsearch-companion
           features:
             - hub-console-only
           skip-e2e: true

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -50,7 +50,7 @@ integration:
       enabled: true
     - id: keycloak-rba
       shortname: kerba
-      enabled: false
+      enabled: true
     - id: keycloak-original-upgrade
       shortname: keyc
       enabled: false

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-console-only.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-console-only.yaml
@@ -3,7 +3,7 @@ auth: keycloak
 flows:
   - upgrade-minor
 identity: keycloak
-persistence: elasticsearch
+persistence: elasticsearch-companion
 features:
   - hub-console-only
 platforms:

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-webmodeler-only.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-webmodeler-only.yaml
@@ -3,7 +3,7 @@ auth: keycloak
 flows:
   - upgrade-minor
 identity: keycloak
-persistence: elasticsearch
+persistence: elasticsearch-companion
 features:
   - hub-webmodeler-only
 platforms:

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/keycloak-original-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/keycloak-original-upgrade.yaml
@@ -3,7 +3,7 @@ auth: keycloak
 flows:
   - upgrade-minor
 identity: keycloak
-persistence: elasticsearch
+persistence: elasticsearch-companion
 platforms:
   - gke
 infra-type:

--- a/scripts/camunda-core/pkg/helm/helm.go
+++ b/scripts/camunda-core/pkg/helm/helm.go
@@ -139,9 +139,11 @@ func DependencyUpdate(ctx context.Context, chartPath string) error {
 }
 
 // RepoAdd registers a Helm chart repository (helm repo add).
-// If the repo already exists, Helm treats this as a no-op update.
+// --force-update makes this idempotent: without it Helm fails with
+// "repository name (%s) already exists" whenever the name is registered under
+// a URL that differs by so much as a trailing slash.
 func RepoAdd(ctx context.Context, name, url string) error {
-	args := []string{"repo", "add", name, url}
+	args := []string{"repo", "add", name, url, "--force-update"}
 	if err := Run(ctx, args, ""); err != nil {
 		return fmt.Errorf("helm repo add %s %s failed: %w", name, url, err)
 	}

--- a/scripts/camunda-core/pkg/helm/helm.go
+++ b/scripts/camunda-core/pkg/helm/helm.go
@@ -138,10 +138,8 @@ func DependencyUpdate(ctx context.Context, chartPath string) error {
 	return nil
 }
 
-// RepoAdd registers a Helm chart repository (helm repo add).
-// --force-update makes this idempotent: without it Helm fails with
-// "repository name (%s) already exists" whenever the name is registered under
-// a URL that differs by so much as a trailing slash.
+// RepoAdd registers a Helm chart repository (helm repo add --force-update),
+// replacing any existing entry registered under the same name.
 func RepoAdd(ctx context.Context, name, url string) error {
 	args := []string{"repo", "add", name, url, "--force-update"}
 	if err := Run(ctx, args, ""); err != nil {

--- a/scripts/deploy-camunda/matrix/chart_dependencies.go
+++ b/scripts/deploy-camunda/matrix/chart_dependencies.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matrix
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type chartDependencyRef struct {
+	Name      string `yaml:"name"`
+	Condition string `yaml:"condition"`
+}
+
+type chartMetaDependencies struct {
+	Dependencies []chartDependencyRef `yaml:"dependencies"`
+}
+
+func readChartDependencies(chartDir string) ([]chartDependencyRef, error) {
+	path := filepath.Join(chartDir, "Chart.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var meta chartMetaDependencies
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return meta.Dependencies, nil
+}
+
+func hasChartDependency(deps []chartDependencyRef, name string) bool {
+	for _, dep := range deps {
+		if dep.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func readYAMLMap(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if doc == nil {
+		doc = map[string]any{}
+	}
+	return doc, nil
+}
+
+// anyConditionKeyTrue splits on "," because Helm treats a condition list as an
+// OR and enables the subchart when any entry resolves true.
+func anyConditionKeyTrue(doc map[string]any, condition string) bool {
+	for _, path := range strings.Split(condition, ",") {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if lookupBoolPath(doc, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func lookupBoolPath(doc map[string]any, dottedPath string) bool {
+	segments := strings.Split(dottedPath, ".")
+	var current any = doc
+	for _, seg := range segments {
+		node, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = node[seg]
+		if !ok {
+			return false
+		}
+	}
+	enabled, ok := current.(bool)
+	return ok && enabled
+}

--- a/scripts/deploy-camunda/matrix/chart_dependencies_test.go
+++ b/scripts/deploy-camunda/matrix/chart_dependencies_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matrix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadChartDependencies(t *testing.T) {
+	dir := t.TempDir()
+	body := "apiVersion: v2\nname: camunda-platform\ndependencies:\n" +
+		"  - name: elasticsearch\n    repository: \"file://../elasticsearch-21\"\n    version: 21.6.3\n    condition: \"elasticsearch.enabled\"\n" +
+		"  - name: common\n    version: 2.x.x\n"
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := readChartDependencies(dir)
+	if err != nil {
+		t.Fatalf("readChartDependencies: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("want 2 dependencies, got %d: %+v", len(deps), deps)
+	}
+	if deps[0].Name != "elasticsearch" || deps[0].Condition != "elasticsearch.enabled" {
+		t.Errorf("dependency 0: got %+v", deps[0])
+	}
+	if deps[1].Name != "common" || deps[1].Condition != "" {
+		t.Errorf("dependency 1: got %+v", deps[1])
+	}
+
+	if !hasChartDependency(deps, "elasticsearch") {
+		t.Error("hasChartDependency(elasticsearch): want true")
+	}
+	if hasChartDependency(deps, "opensearch") {
+		t.Error("hasChartDependency(opensearch): want false")
+	}
+
+	if _, err := readChartDependencies(filepath.Join(dir, "missing")); err == nil {
+		t.Error("want error for a chart dir without Chart.yaml")
+	}
+}
+
+func TestAnyConditionKeyTrue(t *testing.T) {
+	doc := map[string]any{
+		"elasticsearch": map[string]any{"enabled": true},
+		"opensearch":    map[string]any{"enabled": false},
+		"global":        map[string]any{"identity": map[string]any{"auth": map[string]any{"enabled": true}}},
+		"scalar":        "not-a-map",
+		"stringy":       map[string]any{"enabled": "true"},
+	}
+
+	for _, tc := range []struct {
+		condition string
+		want      bool
+	}{
+		{"elasticsearch.enabled", true},
+		{"opensearch.enabled", false},
+		{"global.identity.auth.enabled", true},
+		{"opensearch.enabled,elasticsearch.enabled", true},
+		{"opensearch.enabled, missing.enabled", false},
+		{"missing.enabled", false},
+		{"scalar.enabled", false},
+		{"stringy.enabled", false},
+		{"elasticsearch", false},
+		{"", false},
+	} {
+		if got := anyConditionKeyTrue(doc, tc.condition); got != tc.want {
+			t.Errorf("anyConditionKeyTrue(%q) = %v, want %v", tc.condition, got, tc.want)
+		}
+	}
+}
+
+func TestReadYAMLMap(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.yaml")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readYAMLMap(empty)
+	if err != nil {
+		t.Fatalf("readYAMLMap(empty): %v", err)
+	}
+	if doc == nil {
+		t.Fatal("want an empty map, got nil")
+	}
+	if anyConditionKeyTrue(doc, "elasticsearch.enabled") {
+		t.Error("empty values file must not enable anything")
+	}
+
+	if _, err := readYAMLMap(filepath.Join(dir, "missing.yaml")); err == nil {
+		t.Error("want error for a missing values file")
+	}
+}

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -163,13 +163,15 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 	for _, version := range versions {
 		chartDir := filepath.Join(repoRoot, "charts", fmt.Sprintf("camunda-platform-%s", version))
 
-		cfg, err := LoadRegistry(chartDir)
-		if err != nil {
+		if !HasRegistry(chartDir) {
 			logging.Logger.Warn().
 				Str("version", version).
-				Err(err).
-				Msg("Skipping version — failed to load CI test config")
+				Msg("Skipping version — no CI scenario registry")
 			continue
+		}
+		cfg, err := LoadRegistry(chartDir)
+		if err != nil {
+			return nil, fmt.Errorf("load CI registry for version %s: %w", version, err)
 		}
 
 		// Only PR scenarios

--- a/scripts/deploy-camunda/matrix/registry_test.go
+++ b/scripts/deploy-camunda/matrix/registry_test.go
@@ -614,6 +614,31 @@ func TestRegistryValidatorAcceptsUpgradePersistenceWhenStillBundled(t *testing.T
 	}
 }
 
+func TestRegistryValidatorRejectsUpgradePersistenceMissingFromPreviousVersion(t *testing.T) {
+	_, chartDir, regDir, _ := syntheticChartWithPrevious(t, depsWithElasticsearch, depsWithElasticsearch)
+	writePersistence(t, chartDir, "rdbms-self-signed", "")
+	writeManifest(t, regDir, "    - id: a\n      shortname: a\n      enabled: true\n")
+	writeFile(t, filepath.Join(regDir, "scenarios", "a.yaml"),
+		"name: a\nflows: [upgrade-minor]\nplatforms: [gke]\npersistence: rdbms-self-signed\n")
+
+	_, err := LoadRegistry(chartDir)
+	if err == nil || !strings.Contains(err.Error(), "does not resolve in chart version") {
+		t.Fatalf("want missing previous-version persistence error, got: %v", err)
+	}
+}
+
+func TestRegistryValidatorExemptsModularUpgradePersistenceMissingFromPreviousVersion(t *testing.T) {
+	_, chartDir, regDir, _ := syntheticChartWithPrevious(t, depsWithElasticsearch, depsWithElasticsearch)
+	writePersistence(t, chartDir, "rdbms-self-signed", "")
+	writeManifest(t, regDir, "    - id: a\n      shortname: a\n      enabled: true\n")
+	writeFile(t, filepath.Join(regDir, "scenarios", "a.yaml"),
+		"name: a\nflows: [modular-upgrade-minor]\nplatforms: [gke]\npersistence: rdbms-self-signed\n")
+
+	if _, err := LoadRegistry(chartDir); err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+}
+
 func TestRegistryValidatorAcceptsUpgradePersistenceWithoutPreviousVersion(t *testing.T) {
 	_, chartDir, regDir := syntheticChart(t)
 	writeManifest(t, regDir, "    - id: a\n      shortname: a\n      enabled: true\n")

--- a/scripts/deploy-camunda/matrix/registry_test.go
+++ b/scripts/deploy-camunda/matrix/registry_test.go
@@ -517,6 +517,114 @@ func TestRegistryValidatorRejectsMissingScript(t *testing.T) {
 	}
 }
 
+func TestRegistryValidatorRejectsMissingPersistenceValues(t *testing.T) {
+	abs := absChartDir(t)
+	cfg, err := LoadRegistry(abs)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	cfg.Integration.Case.PR.Scenarios[0].Persistence = "nonexistent-persistence"
+	err = (&RegistryValidator{ChartDir: abs}).Validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "nonexistent-persistence") {
+		t.Fatalf("want missing-persistence error, got: %v", err)
+	}
+}
+
+const (
+	depsWithoutElasticsearch = "  - name: common\n    version: 2.x.x\n"
+	depsWithElasticsearch    = "  - name: elasticsearch\n    version: 21.6.3\n    condition: \"elasticsearch.enabled\"\n  - name: common\n    version: 2.x.x\n"
+)
+
+func TestRegistryValidatorRejectsUnmitigatedBitnamiPersistenceDrop(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		flow string
+	}{
+		{"two-step upgrade", "upgrade-minor"},
+		{"modular upgrade", "modular-upgrade-minor"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, chartDir, regDir, _ := syntheticChartWithPrevious(t, depsWithoutElasticsearch, depsWithElasticsearch)
+			writeManifest(t, regDir, "    - id: a\n      shortname: a\n      enabled: true\n")
+			writeFile(t, filepath.Join(regDir, "scenarios", "a.yaml"),
+				"name: a\nflows: ["+tc.flow+"]\nplatforms: [gke]\npersistence: elasticsearch\n")
+
+			_, err := LoadRegistry(chartDir)
+			if err == nil || !strings.Contains(err.Error(), "this chart no longer bundles") {
+				t.Fatalf("want dropped-subchart persistence error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRegistryValidatorExemptsMitigatedBitnamiPersistenceDrop(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		scenario string
+		withHook bool
+	}{
+		{
+			name:     "companion persistence layer",
+			scenario: "name: a\nflows: [upgrade-minor]\nplatforms: [gke]\npersistence: elasticsearch-companion\n",
+		},
+		{
+			name:     "migration hook declared",
+			scenario: "name: a\nflows: [upgrade-minor]\nplatforms: [gke]\npersistence: elasticsearch\npost-infra: mig\n",
+			withHook: true,
+		},
+		{
+			name:     "install flow",
+			scenario: "name: a\nflows: [install]\nplatforms: [gke]\npersistence: elasticsearch\n",
+		},
+		{
+			name:     "upgrade-patch flow",
+			scenario: "name: a\nflows: [upgrade-patch]\nplatforms: [gke]\npersistence: elasticsearch\n",
+		},
+		{
+			name:     "no persistence field",
+			scenario: "name: a\nflows: [upgrade-minor]\nplatforms: [gke]\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, chartDir, regDir, _ := syntheticChartWithPrevious(t, depsWithoutElasticsearch, depsWithElasticsearch)
+			writeManifest(t, regDir, "    - id: a\n      shortname: a\n      enabled: true\n")
+			writeFile(t, filepath.Join(regDir, "scenarios", "a.yaml"), tc.scenario)
+			if tc.withHook {
+				writeFile(t, filepath.Join(regDir, "hooks", "mig.yaml"),
+					"description: migrate off the dropped subchart\nscript: "+bitnamiMigrationHookScript+"\n")
+				writeFile(t, filepath.Join(chartDir, "test", "integration", "scenarios", "pre-setup-scripts", bitnamiMigrationHookScript),
+					"#!/usr/bin/env bash\n")
+			}
+
+			if _, err := LoadRegistry(chartDir); err != nil {
+				t.Fatalf("want no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRegistryValidatorAcceptsUpgradePersistenceWhenStillBundled(t *testing.T) {
+	_, chartDir, regDir, _ := syntheticChartWithPrevious(t, depsWithElasticsearch, depsWithElasticsearch)
+	writeManifest(t, regDir, "    - id: a\n      shortname: a\n      enabled: true\n")
+	writeFile(t, filepath.Join(regDir, "scenarios", "a.yaml"),
+		"name: a\nflows: [upgrade-minor]\nplatforms: [gke]\npersistence: elasticsearch\n")
+
+	if _, err := LoadRegistry(chartDir); err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+}
+
+func TestRegistryValidatorAcceptsUpgradePersistenceWithoutPreviousVersion(t *testing.T) {
+	_, chartDir, regDir := syntheticChart(t)
+	writeManifest(t, regDir, "    - id: a\n      shortname: a\n      enabled: true\n")
+	writeFile(t, filepath.Join(regDir, "scenarios", "a.yaml"),
+		"name: a\nflows: [upgrade-minor]\nplatforms: [gke]\npersistence: elasticsearch\n")
+
+	if _, err := LoadRegistry(chartDir); err != nil {
+		t.Fatalf("want no error, got: %v", err)
+	}
+}
+
 // TestRegistryValidatorRejectsMissingFeatureValues exercises checkFeature.
 // Feature names resolve to <feature>.yaml under chart-full-setup/values/features/;
 // a dangling name must surface as a validation error so PR review catches
@@ -659,6 +767,7 @@ func syntheticChart(t *testing.T) (string, string, string) {
 		filepath.Join(chartDir, "test", "integration", "scenarios", "common", "resources"),
 		filepath.Join(chartDir, "test", "integration", "scenarios", "pre-setup-scripts"),
 		filepath.Join(chartDir, "test", "integration", "scenarios", "chart-full-setup", "values", "features"),
+		filepath.Join(chartDir, "test", "integration", "scenarios", "chart-full-setup", "values", "persistence"),
 		filepath.Join(dir, ".github", "config"),
 	}
 	for _, d := range dirs {
@@ -668,7 +777,33 @@ func syntheticChart(t *testing.T) (string, string, string) {
 	}
 	// Permissive default so tests that don't care about permitted-flows pass.
 	writePermittedFlows(t, dir, "rules: []\n")
+	writePersistence(t, chartDir, "elasticsearch", "")
 	return dir, chartDir, regDir
+}
+
+func writePersistence(t *testing.T, chartDir, name, body string) {
+	t.Helper()
+	dir := filepath.Join(chartDir, "test", "integration", "scenarios", "chart-full-setup", "values", "persistence")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, name+".yaml"), body)
+}
+
+func syntheticChartWithPrevious(t *testing.T, currentDeps, prevDeps string) (string, string, string, string) {
+	t.Helper()
+	repoRoot, chartDir, regDir := syntheticChart(t)
+	writeFile(t, filepath.Join(chartDir, "Chart.yaml"), "name: camunda-platform\ndependencies:\n"+currentDeps)
+	writePersistence(t, chartDir, "elasticsearch-companion", "")
+
+	prevChartDir := filepath.Join(repoRoot, "charts", "camunda-platform-99.98")
+	if err := os.MkdirAll(prevChartDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(prevChartDir, "Chart.yaml"), "name: camunda-platform\ndependencies:\n"+prevDeps)
+	writePersistence(t, prevChartDir, "elasticsearch", "elasticsearch:\n  enabled: true\n")
+	writePersistence(t, prevChartDir, "elasticsearch-companion", "elasticsearch:\n  enabled: false\n")
+	return repoRoot, chartDir, regDir, prevChartDir
 }
 
 // writeManifest writes a minimal manifest.yaml whose scenarios block is the

--- a/scripts/deploy-camunda/matrix/registry_validator.go
+++ b/scripts/deploy-camunda/matrix/registry_validator.go
@@ -22,7 +22,13 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"scripts/camunda-core/pkg/versionmatrix"
 )
+
+const bitnamiMigrationHookScript = "post-infra-bitnami-migration.sh"
+
+const bitnamiMigrationHookID = "post-infra-bitnami-migration"
 
 // RegistryValidator enforces the registry's load-time invariants from
 // ADR 0093 §3:
@@ -30,8 +36,11 @@ import (
 //   - every LifecycleHook passes LifecycleHook.Validate (description set,
 //     exactly one of fixtures or script, plain basenames);
 //   - referenced basenames (hook fixtures under common/resources/, hook
-//     scripts under pre-setup-scripts/, feature values-files, dependency
-//     values-files) resolve to existing files;
+//     scripts under pre-setup-scripts/, feature values-files, persistence
+//     values-files, dependency values-files) resolve to existing files;
+//   - no upgrade-flow scenario selects a persistence layer that enables, in the
+//     previous chart version, a subchart this chart no longer bundles, unless a
+//     migration hook bridges the two backends;
 //   - no two post-fan-out CIScenario entries collide on
 //     (Shortname, Flow, Platform) after applying matrix.Generate's flow
 //     defaulting (empty flow treated as "install") — the natural CI namespace key;
@@ -71,6 +80,7 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 	scriptsDir := filepath.Join(scenariosDir, "pre-setup-scripts")
 	chartFullSetupDir := filepath.Join(scenariosDir, "chart-full-setup")
 	featuresDir := filepath.Join(chartFullSetupDir, "values", "features")
+	persistenceDir := filepath.Join(chartFullSetupDir, "values", "persistence")
 	registryDepsDir := filepath.Join(v.ChartDir, "test", RegistryDirName, "dependencies")
 
 	// Referenced-set tracking — feeds the orphan walks below. Populated as a
@@ -111,6 +121,12 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 			problems = append(problems, fmt.Sprintf("%s: feature %q: missing values file at %s", ctx, feature, fPath))
 		}
 	}
+	checkPersistence := func(ctx, persistence string) {
+		pPath := filepath.Join(persistenceDir, persistence+".yaml")
+		if info, err := os.Stat(pPath); err != nil || info.IsDir() {
+			problems = append(problems, fmt.Sprintf("%s: persistence %q: missing values file at %s", ctx, persistence, pPath))
+		}
+	}
 	// Per-scenario extra-values resolution: relative paths resolve against the
 	// scenario's chart-full-setup dir (matching appendScenarioExtraValues in
 	// runner_execute.go); absolute paths are runtime-supplied and not validated.
@@ -145,6 +161,51 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 			return
 		} else if info.IsDir() {
 			problems = append(problems, fmt.Sprintf("%s: dependency %s: values-file %q: is a directory at %s", ctx, dep.ReleaseName, dep.ValuesFile, path))
+		}
+	}
+
+	currentDeps, currentDepsErr := readChartDependencies(v.ChartDir)
+	prevVersion, prevVersionErr := versionmatrix.PreviousAppVersion(version)
+	var (
+		prevDeps           []chartDependencyRef
+		prevDepsErr        error
+		prevPersistenceDir string
+	)
+	if prevVersionErr == nil {
+		prevChartDir := filepath.Join(repoRoot, "charts", "camunda-platform-"+prevVersion)
+		prevDeps, prevDepsErr = readChartDependencies(prevChartDir)
+		prevPersistenceDir = filepath.Join(prevChartDir, "test", "integration", "scenarios", "chart-full-setup", "values", "persistence")
+	}
+
+	checkUpgradePersistence := func(ctx string, scn CIScenario, effectiveFlow string) {
+		if scn.Persistence == "" {
+			return
+		}
+		if effectiveFlow != "upgrade-minor" && !versionmatrix.IsUpgradeOnlyFlow(effectiveFlow) {
+			return
+		}
+		if prevVersionErr != nil || currentDepsErr != nil || prevDepsErr != nil {
+			return
+		}
+		prevValues, err := readYAMLMap(filepath.Join(prevPersistenceDir, scn.Persistence+".yaml"))
+		if err != nil {
+			return
+		}
+		for _, dep := range prevDeps {
+			if dep.Condition == "" || hasChartDependency(currentDeps, dep.Name) {
+				continue
+			}
+			if !anyConditionKeyTrue(prevValues, dep.Condition) {
+				continue
+			}
+			if scn.PostInfra != nil && scn.PostInfra.Script == bitnamiMigrationHookScript {
+				continue
+			}
+			problems = append(problems, fmt.Sprintf(
+				"%s: persistence %q resolves in chart version %s to a values file that enables subchart %q (%s: true), which this chart no longer bundles"+
+					" — the upgrade would address two different backends and start against empty storage;"+
+					" select a companion persistence layer both versions can reach, or declare \"post-infra: %s\" to migrate the data first",
+				ctx, scn.Persistence, prevVersion, dep.Name, dep.Condition, bitnamiMigrationHookID))
 		}
 	}
 
@@ -183,6 +244,9 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 		for _, dep := range scn.Dependencies {
 			checkDep(label, dep)
 		}
+		if scn.Persistence != "" {
+			checkPersistence(label, scn.Persistence)
+		}
 		if scn.Topology != nil {
 			if err := scn.Topology.Validate(label, chartFullSetupDir, registryDepsDir); err != nil {
 				problems = append(problems, err.Error())
@@ -216,6 +280,8 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 		if effectiveFlow == "" {
 			effectiveFlow = "install"
 		}
+
+		checkUpgradePersistence(label, scn, effectiveFlow)
 
 		if pf != nil {
 			permitted := FilterFlows(pf, version, []string{effectiveFlow})

--- a/scripts/deploy-camunda/matrix/registry_validator.go
+++ b/scripts/deploy-camunda/matrix/registry_validator.go
@@ -189,6 +189,13 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 		}
 		prevValues, err := readYAMLMap(filepath.Join(prevPersistenceDir, scn.Persistence+".yaml"))
 		if err != nil {
+			if effectiveFlow == "upgrade-minor" {
+				problems = append(problems, fmt.Sprintf(
+					"%s: persistence %q does not resolve in chart version %s (%v)"+
+						" — step 1 of the two-step upgrade installs that chart from its own scenario dir;"+
+						" add the layer there or select one both versions provide",
+					ctx, scn.Persistence, prevVersion, err))
+			}
 			return
 		}
 		for _, dep := range prevDeps {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6907.

### What's in this PR?

`hub-console-only`, `hub-webmodeler-only` and `keycloak-original-upgrade` run a two-step 8.9→8.10 upgrade with `persistence: elasticsearch` and no migration hook. Step 1 resolves its values from the previous chart's scenario dir (`step1Flags.Deployment.ScenarioPath` in `runner_upgrade.go`), where 8.9 enables the bundled Bitnami Elasticsearch; 8.10 bundles none. The two steps address different instances and 8.10 starts against empty secondary storage.

The nine other scenarios #6907 lists already carry `post-infra: post-infra-bitnami-migration`, which warm-reindexes `camunda-*` onto the companion. Flipping those would leave nothing at the Bitnami source for the hook's ES phase, so they are unchanged. `qa-opensearch-upg-modular` has no equivalent split — `opensearch-embedded` is the companion release in both 8.9 and 8.10.

- The three scenarios select `elasticsearch-companion`, the layer added in #6906. All three already declare the `elasticsearch` dependency.
- `keycloak-rba` is re-enabled. #6454's `43c0097f92` disabled it pending the companion layer; #6906 landed that layer and enabled it on 2026-08-24, then #6454 merged on 2026-08-28 with its stale `enabled: false`.
- `RegistryValidator` gains two rules: a persistence values-file existence check mirroring `checkFeature`, and an upgrade-flow check that rejects a persistence layer enabling — in the previous chart version — a subchart the current chart no longer bundles, unless a companion layer or the migration hook bridges it. The second reads the previous `Chart.yaml`'s dependency conditions against the current dependency list rather than a hardcoded pair list, so a future minor dropping a different subchart is caught with no code change. It does not fire on `install` or `upgrade-patch`, and the 8.7/8.8/8.9 registries are unaffected because those charts still bundle Elasticsearch.
- The validator also fails the registry load when an `upgrade-minor` scenario's persistence layer has no values file in the previous chart version. Step 1 resolves its values from that chart's scenario dir and drops only unknown features, never persistence, so the layer must exist there. `modular-upgrade-minor` is exempt: `executeUpgradeOnly` never reads the previous version's persistence dir.
- `matrix.Generate` now gates on `HasRegistry` and propagates a `LoadRegistry` failure instead of warning and skipping the chart version, which silently shrank the CI matrix.
- `helm.RepoAdd` passes `--force-update`. Without it `helm repo add` fails with `repository name (camunda) already exists` whenever the name is registered under a URL differing by a trailing slash, which blocks `matrix run` on any machine that already has the repo.
- `go.addlicense-files` excludes `*/node_modules/*`, so the target stops tripping on vendored Go files under `test/e2e/node_modules` after `npm ci`.

Verified on GKE (`distro-ci`), `upgrade-minor` flow:

| scenario | result | time |
|---|---|---|
| `kerba` | Success 1 / Failed 0 | 5m40s |
| `hubwo` | Success 1 / Failed 0 | 10m15s |
| `hubco` | Success 1 / Failed 0 | 4m45s |

Post-upgrade counts in the companion instance, identical across all three — `camunda-authorization-8.8.0_` 56, `camunda-role-8.8.0_` 13, `camunda-tenant-8.8.0_` 6, `camunda-mapping-rule-8.8.0_` 3. One `elasticsearch-master-0` pod per namespace and no Bitnami subchart pod.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

