### PR TITLE
ci: move chart-CI change detection into the matrix planner

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -71,11 +71,9 @@ runs:
         echo "::group::Action Inputs"
         echo "${GITHUB_CONTEXT}"
         echo "::endgroup::"
-    - name: Get changed dirs
+    - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
-      with:
-        dir_names: "true"
     - name: Get chart versions
       id: get-chart-versions
       uses: ./.github/actions/get-chart-versions

--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -74,6 +74,8 @@ runs:
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+      with:
+        output_renamed_files_as_deleted_and_added: "true"
     - name: Get chart versions
       id: get-chart-versions
       uses: ./.github/actions/get-chart-versions

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -114,8 +114,8 @@ jobs:
     name: Generate chart matrix
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.annotate-cache.outputs.matrix || steps.generate-chart-versions.outputs.matrix || steps.empty-matrix.outputs.matrix }}
-      camunda-versions: ${{ steps.generate-chart-versions.outputs.camunda-versions || steps.empty-matrix.outputs.camunda-versions }}
+      matrix: ${{ steps.annotate-cache.outputs.matrix || steps.generate-chart-versions.outputs.matrix }}
+      camunda-versions: ${{ steps.generate-chart-versions.outputs.camunda-versions }}
       workspace: ${{ github.workspace }}
       pr-head-sha: ${{ steps.resolve-pr-sha.outputs.pr-head-sha }}
     steps:
@@ -123,43 +123,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Detect whether any chart/CI-relevant files changed. On non-PR events
-      # (merge_group, workflow_dispatch) we always consider changes present.
-      - name: Detect relevant file changes
-        id: changes
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        with:
-          filters: |
-            charts:
-              - '.github/workflows/chart-validate-template.yaml'
-              - '.github/workflows/test-unit-template.yaml'
-              - '.github/workflows/test-integration-runner.yaml'
-              - '.github/workflows/test-integration-template.yaml'
-              - '.github/workflows/test-chart-version-template.yaml'
-              - '.github/workflows/test-chart-version.yaml'
-              - '.github/config/external-secret/**'
-              - 'scripts/**'
-              - 'test/e2e/**'
-              - '.tool-versions'
-              - 'charts/camunda-platform-8*/**'
-              - '!charts/camunda-platform-8*/*.md'
-              - '!charts/camunda-platform-8*/*.MD'
-              - '!charts/camunda-platform-8*/*.txt'
-
-      # Short-circuit: if no relevant files changed, emit empty matrix and skip
-      # all downstream jobs. CI Gate (if: always()) still reports success.
-      - name: Emit empty matrix (no relevant changes)
-        id: empty-matrix
-        if: github.event_name == 'pull_request' && steps.changes.outputs.charts != 'true'
-        run: |
-          echo "No chart/CI files changed — emitting empty matrix."
-          echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-          echo 'camunda-versions=[]' >> "$GITHUB_OUTPUT"
-
       - name: Generate chart versions
         id: generate-chart-versions
-        if: github.event_name != 'pull_request' || steps.changes.outputs.charts == 'true'
         uses: ./.github/actions/generate-chart-matrix
         with:
           manual-trigger: ${{ github.event.inputs.manual-trigger }}

--- a/scripts/deploy-camunda/matrix/plan.go
+++ b/scripts/deploy-camunda/matrix/plan.go
@@ -144,7 +144,17 @@ var buildAllTriggers = []buildAllTrigger{
 		Pattern:     regexp.MustCompile(`(^|[[:space:]])scripts(/|$|[[:space:]])`),
 		Description: "scripts/ (any helper script)",
 	},
+	{
+		Pattern:     regexp.MustCompile(`^\.tool-versions$`),
+		Description: ".tool-versions (toolchain pins)",
+	},
+	{
+		Pattern:     regexp.MustCompile(`^test/e2e/`),
+		Description: "test/e2e/ (shared Playwright config)",
+	},
 }
+
+var chartDocPath = regexp.MustCompile(`^charts/camunda-platform-8[^/]*/[^/]+\.(md|MD|txt)$`)
 
 var manualFlowPattern = regexp.MustCompile(`^(install|upgrade-patch|upgrade-minor)(,(install|upgrade-patch|upgrade-minor))*$`)
 
@@ -234,7 +244,12 @@ func selectPlanVersions(repoRoot string, opts PlanOptions) ([]string, error) {
 		return []string{opts.ManualTrigger}, nil
 	}
 
-	paths := strings.Fields(opts.ChangedFiles)
+	var paths []string
+	for _, path := range strings.Fields(opts.ChangedFiles) {
+		if !chartDocPath.MatchString(path) {
+			paths = append(paths, path)
+		}
+	}
 	for _, trigger := range buildAllTriggers {
 		if triggerFires(trigger, paths) {
 			return opts.ActiveVersions, nil

--- a/scripts/deploy-camunda/matrix/plan_test.go
+++ b/scripts/deploy-camunda/matrix/plan_test.go
@@ -225,6 +225,94 @@ func TestPlanBareScriptsTokenTriggersAll(t *testing.T) {
 	}
 }
 
+func TestPlanChartDocOnlyEmptyMatrix(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/README.md charts/camunda-platform-8.10/RELEASE-NOTES.md",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	matrixJSON, err := result.MatrixJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matrixJSON != `{"include":[]}` {
+		t.Errorf("matrix = %s, want empty include", matrixJSON)
+	}
+}
+
+func TestPlanChartDocWithTemplateChangeBuildsVersion(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/README.md charts/camunda-platform-8.10/templates/common/_helpers.tpl",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 1 || got[0] != "8.10" {
+		t.Errorf("versions = %v, want [8.10]", got)
+	}
+}
+
+func TestPlanChartNotesTxtIsNotDoc(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/templates/NOTES.txt",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 1 || got[0] != "8.10" {
+		t.Errorf("versions = %v, want [8.10]", got)
+	}
+}
+
+func TestPlanToolVersionsTriggersAll(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   ".tool-versions",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != len(planActiveVersions) {
+		t.Errorf("versions = %v, want all of %v", got, planActiveVersions)
+	}
+}
+
+func TestPlanSharedE2EConfigTriggersAll(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "test/e2e/playwright.base.config.ts",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != len(planActiveVersions) {
+		t.Errorf("versions = %v, want all of %v", got, planActiveVersions)
+	}
+}
+
+func TestPlanChartScopedE2EPathOnlyTriggersChart(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/test/e2e/foo.spec.ts",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 1 || got[0] != "8.10" {
+		t.Errorf("versions = %v, want [8.10]", got)
+	}
+}
+
 func TestPlanUnrelatedPathEmptyMatrix(t *testing.T) {
 	result, err := Plan(findRepoRoot(t), PlanOptions{
 		ActiveVersions: planActiveVersions,


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6971.

### What's in this PR?

Chart-CI change detection moves out of the `dorny/paths-filter` gate and into `matrix.Plan`, so one rule set applies to `pull_request`, `merge_group`, and `workflow_dispatch` alike.

- `.github/workflows/test-chart-version.yaml`: removed `Detect relevant file changes` and `Emit empty matrix (no relevant changes)`, and the `if:` guard they fed on `Generate chart versions`. The `charts` rule could never evaluate to `false` — `dorny/paths-filter` defaults to `predicate-quantifier: some`, which ORs `!charts/camunda-platform-8*/*.md` in as a matcher that is true for every file that is not a chart-root `.md`. The job outputs no longer fall back to `steps.empty-matrix`.
- `.github/actions/generate-chart-matrix/action.yaml`: dropped `dir_names: "true"` from `tj-actions/changed-files`. It collapsed repo-root files to `.`, which is why `.tool-versions` could never select a version. p95 is 41 changed files per PR; a 100-file PR joins to ~8.4 KB.
- `scripts/deploy-camunda/matrix/plan.go`: `selectPlanVersions` drops `charts/camunda-platform-8*/<name>.{md,MD,txt}` before version detection (chart root only, so `templates/NOTES.txt` still selects its version), and `buildAllTriggers` gains `.tool-versions` and `test/e2e/`.

Verified with `deploy-camunda matrix plan --active-versions "8.7 8.8 8.9 8.10"`:

| `--all-modified-files` | before | after |
|---|---|---|
| `charts/camunda-platform-8.10/README.md` | all four | `[]` |
| `charts/camunda-platform-8.10/templates/NOTES.txt` | `8.10` | `8.10` |
| `.tool-versions` | `[]` | all four |
| `test/e2e/playwright.base.config.ts` | `[]` | all four |

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
