### PR TITLE
ci: scope build-all matrix triggers to chart-CI paths

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -71,11 +71,9 @@ runs:
         echo "::group::Action Inputs"
         echo "${GITHUB_CONTEXT}"
         echo "::endgroup::"
-    - name: Get changed dirs
+    - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
-      with:
-        dir_names: "true"
     - name: Get chart versions
       id: get-chart-versions
       uses: ./.github/actions/get-chart-versions

--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -74,6 +74,8 @@ runs:
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+      with:
+        output_renamed_files_as_deleted_and_added: "true"
     - name: Get chart versions
       id: get-chart-versions
       uses: ./.github/actions/get-chart-versions

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -114,8 +114,8 @@ jobs:
     name: Generate chart matrix
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.annotate-cache.outputs.matrix || steps.generate-chart-versions.outputs.matrix || steps.empty-matrix.outputs.matrix }}
-      camunda-versions: ${{ steps.generate-chart-versions.outputs.camunda-versions || steps.empty-matrix.outputs.camunda-versions }}
+      matrix: ${{ steps.annotate-cache.outputs.matrix || steps.generate-chart-versions.outputs.matrix }}
+      camunda-versions: ${{ steps.generate-chart-versions.outputs.camunda-versions }}
       workspace: ${{ github.workspace }}
       pr-head-sha: ${{ steps.resolve-pr-sha.outputs.pr-head-sha }}
     steps:
@@ -123,43 +123,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Detect whether any chart/CI-relevant files changed. On non-PR events
-      # (merge_group, workflow_dispatch) we always consider changes present.
-      - name: Detect relevant file changes
-        id: changes
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        with:
-          filters: |
-            charts:
-              - '.github/workflows/chart-validate-template.yaml'
-              - '.github/workflows/test-unit-template.yaml'
-              - '.github/workflows/test-integration-runner.yaml'
-              - '.github/workflows/test-integration-template.yaml'
-              - '.github/workflows/test-chart-version-template.yaml'
-              - '.github/workflows/test-chart-version.yaml'
-              - '.github/config/external-secret/**'
-              - 'scripts/**'
-              - 'test/e2e/**'
-              - '.tool-versions'
-              - 'charts/camunda-platform-8*/**'
-              - '!charts/camunda-platform-8*/*.md'
-              - '!charts/camunda-platform-8*/*.MD'
-              - '!charts/camunda-platform-8*/*.txt'
-
-      # Short-circuit: if no relevant files changed, emit empty matrix and skip
-      # all downstream jobs. CI Gate (if: always()) still reports success.
-      - name: Emit empty matrix (no relevant changes)
-        id: empty-matrix
-        if: github.event_name == 'pull_request' && steps.changes.outputs.charts != 'true'
-        run: |
-          echo "No chart/CI files changed — emitting empty matrix."
-          echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-          echo 'camunda-versions=[]' >> "$GITHUB_OUTPUT"
-
       - name: Generate chart versions
         id: generate-chart-versions
-        if: github.event_name != 'pull_request' || steps.changes.outputs.charts == 'true'
         uses: ./.github/actions/generate-chart-matrix
         with:
           manual-trigger: ${{ github.event.inputs.manual-trigger }}

--- a/scripts/deploy-camunda/matrix/plan.go
+++ b/scripts/deploy-camunda/matrix/plan.go
@@ -144,7 +144,17 @@ var buildAllTriggers = []buildAllTrigger{
 		Pattern:     regexp.MustCompile(`(^|[[:space:]])scripts(/|$|[[:space:]])`),
 		Description: "scripts/ (any helper script)",
 	},
+	{
+		Pattern:     regexp.MustCompile(`^\.tool-versions$`),
+		Description: ".tool-versions (toolchain pins)",
+	},
+	{
+		Pattern:     regexp.MustCompile(`^test/e2e/`),
+		Description: "test/e2e/ (shared Playwright config)",
+	},
 }
+
+var chartDocPath = regexp.MustCompile(`^charts/camunda-platform-8[^/]*/[^/]+\.(md|MD|txt)$`)
 
 var manualFlowPattern = regexp.MustCompile(`^(install|upgrade-patch|upgrade-minor)(,(install|upgrade-patch|upgrade-minor))*$`)
 
@@ -234,7 +244,12 @@ func selectPlanVersions(repoRoot string, opts PlanOptions) ([]string, error) {
 		return []string{opts.ManualTrigger}, nil
 	}
 
-	paths := strings.Fields(opts.ChangedFiles)
+	var paths []string
+	for _, path := range strings.Fields(opts.ChangedFiles) {
+		if !chartDocPath.MatchString(path) {
+			paths = append(paths, path)
+		}
+	}
 	for _, trigger := range buildAllTriggers {
 		if triggerFires(trigger, paths) {
 			return opts.ActiveVersions, nil

--- a/scripts/deploy-camunda/matrix/plan.go
+++ b/scripts/deploy-camunda/matrix/plan.go
@@ -125,12 +125,64 @@ type buildAllTrigger struct {
 	Description string
 }
 
+var chartCIWorkflows = []string{
+	"build-ci-runner-image",
+	"chart-validate-template",
+	"cleanup-namespace",
+	"integration-tests-gate",
+	"test-chart-version",
+	"test-chart-version-template",
+	"test-integration-cleanup-template",
+	"test-integration-diagnostics-template",
+	"test-integration-runner",
+	"test-integration-template",
+	"test-local-template",
+	"test-unit-template",
+}
+
+var deployRelevantScriptDirs = []string{
+	"camunda-core",
+	"ci-result-cache",
+	"deploy-camunda",
+	"integration-tests-gate",
+	"playwright-pin",
+	"prepare-helm-values",
+	"validate-values-schema",
+	"vault-secret-mapper",
+}
+
+var deployRelevantScriptFiles = []string{
+	"base_playwright_script.sh",
+	"check-no-plaintext-datastore.sh",
+	"check-values-enterprise.sh",
+	"check-values-latest.sh",
+	"deploy-camunda.sh",
+	"dns-fallback.cjs",
+	"download-chart-docker-images.sh",
+	"harbor-retry.sh",
+	"prepare-helm-values.sh",
+	"render-e2e-env.sh",
+	"run-e2e-tests.sh",
+}
+
+func alternation(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, regexp.QuoteMeta(name))
+	}
+	return strings.Join(quoted, "|")
+}
+
 // buildAllTriggers mirrors the BUILD_ALL_TRIGGERS list of the bash
 // implementation. Patterns are matched per changed path, like grep.
 var buildAllTriggers = []buildAllTrigger{
 	{
-		Pattern:     regexp.MustCompile(`\.github/(workflows|actions)`),
-		Description: ".github/workflows or .github/actions",
+		Pattern:     regexp.MustCompile(`^\.github/workflows/(` + alternation(chartCIWorkflows) + `)\.yaml$`),
+		Description: ".github/workflows (chart-CI workflows)",
+	},
+	{
+		Pattern:     regexp.MustCompile(`^\.github/actions/`),
+		Description: ".github/actions",
 	},
 	{
 		Pattern:     regexp.MustCompile(`\.github/config`),
@@ -138,11 +190,12 @@ var buildAllTriggers = []buildAllTrigger{
 		Description: ".github/config (excluding release-please)",
 	},
 	{
-		// Anchor required: tj-actions/changed-files with dir_names:true emits
-		// the bare token "scripts" so unanchored "scripts/" misses top-level
-		// helper changes.
-		Pattern:     regexp.MustCompile(`(^|[[:space:]])scripts(/|$|[[:space:]])`),
-		Description: "scripts/ (any helper script)",
+		Pattern:     regexp.MustCompile(`^scripts/(` + alternation(deployRelevantScriptDirs) + `)/`),
+		Description: "scripts/ (deployer and its runtime dependencies)",
+	},
+	{
+		Pattern:     regexp.MustCompile(`^scripts/(` + alternation(deployRelevantScriptFiles) + `)$`),
+		Description: "scripts/ (deploy and e2e helpers)",
 	},
 	{
 		Pattern:     regexp.MustCompile(`^\.tool-versions$`),

--- a/scripts/deploy-camunda/matrix/plan_allowlist_test.go
+++ b/scripts/deploy-camunda/matrix/plan_allowlist_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matrix
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+var localUses = regexp.MustCompile(`uses:\s*\./\.github/(workflows/[\w.-]+\.ya?ml|actions/[\w.-]+)`)
+
+func chartCIUsesClosure(t *testing.T, repoRoot string) map[string]bool {
+	t.Helper()
+	reachable := map[string]bool{}
+	queue := []string{"workflows/test-chart-version.yaml"}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if reachable[current] {
+			continue
+		}
+		reachable[current] = true
+
+		candidates := []string{filepath.Join(repoRoot, ".github", current)}
+		if !filepath.IsAbs(current) && filepath.Ext(current) == "" {
+			candidates = []string{
+				filepath.Join(repoRoot, ".github", current, "action.yaml"),
+				filepath.Join(repoRoot, ".github", current, "action.yml"),
+			}
+		}
+		for _, candidate := range candidates {
+			content, err := os.ReadFile(candidate)
+			if err != nil {
+				continue
+			}
+			for _, match := range localUses.FindAllStringSubmatch(string(content), -1) {
+				queue = append(queue, match[1])
+			}
+		}
+	}
+	return reachable
+}
+
+func TestChartCIWorkflowAllowlistCoversUsesClosure(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	pattern := buildAllTriggers[0].Pattern
+	for reached := range chartCIUsesClosure(t, repoRoot) {
+		if filepath.Ext(reached) == "" {
+			continue
+		}
+		path := ".github/" + reached
+		if !pattern.MatchString(path) {
+			t.Errorf("%s is reachable from test-chart-version.yaml but is not in chartCIWorkflows; "+
+				"a change to it would no longer build any chart version", path)
+		}
+	}
+}
+
+func TestChartCIWorkflowAllowlistEntriesExist(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	for _, name := range chartCIWorkflows {
+		path := filepath.Join(repoRoot, ".github", "workflows", name+".yaml")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("chartCIWorkflows entry %q has no workflow at %s", name, path)
+		}
+	}
+}
+
+func TestDeployRelevantScriptAllowlistEntriesExist(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	for _, name := range deployRelevantScriptDirs {
+		info, err := os.Stat(filepath.Join(repoRoot, "scripts", name))
+		if err != nil || !info.IsDir() {
+			t.Errorf("deployRelevantScriptDirs entry %q is not a directory under scripts/", name)
+		}
+	}
+	for _, name := range deployRelevantScriptFiles {
+		if _, err := os.Stat(filepath.Join(repoRoot, "scripts", name)); err != nil {
+			t.Errorf("deployRelevantScriptFiles entry %q does not exist under scripts/", name)
+		}
+	}
+}

--- a/scripts/deploy-camunda/matrix/plan_allowlist_test.go
+++ b/scripts/deploy-camunda/matrix/plan_allowlist_test.go
@@ -23,6 +23,12 @@ import (
 
 var localUses = regexp.MustCompile(`uses:\s*\./\.github/(workflows/[\w.-]+\.ya?ml|actions/[\w.-]+)`)
 
+var scriptsReference = regexp.MustCompile(`scripts/([A-Za-z0-9_.-]+)`)
+
+var chartCIScriptWaivers = map[string]string{
+	"list-chart-image-commits.sh": "diagnostic output only: both call sites in test-integration-runner.yaml are `if: always()` with `continue-on-error: true`, so it cannot change a chart-CI result",
+}
+
 func chartCIUsesClosure(t *testing.T, repoRoot string) map[string]bool {
 	t.Helper()
 	reachable := map[string]bool{}
@@ -91,6 +97,45 @@ func TestDeployRelevantScriptAllowlistEntriesExist(t *testing.T) {
 	for _, name := range deployRelevantScriptFiles {
 		if _, err := os.Stat(filepath.Join(repoRoot, "scripts", name)); err != nil {
 			t.Errorf("deployRelevantScriptFiles entry %q does not exist under scripts/", name)
+		}
+	}
+}
+
+func TestDeployRelevantScriptAllowlistCoversChartCIReferences(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	allowed := map[string]bool{}
+	for _, name := range deployRelevantScriptDirs {
+		allowed[name] = true
+	}
+	for _, name := range deployRelevantScriptFiles {
+		allowed[name] = true
+	}
+
+	for reached := range chartCIUsesClosure(t, repoRoot) {
+		candidates := []string{filepath.Join(repoRoot, ".github", reached)}
+		if filepath.Ext(reached) == "" {
+			candidates = []string{
+				filepath.Join(repoRoot, ".github", reached, "action.yaml"),
+				filepath.Join(repoRoot, ".github", reached, "action.yml"),
+			}
+		}
+		for _, candidate := range candidates {
+			content, err := os.ReadFile(candidate)
+			if err != nil {
+				continue
+			}
+			for _, match := range scriptsReference.FindAllStringSubmatch(string(content), -1) {
+				segment := match[1]
+				if allowed[segment] {
+					continue
+				}
+				if reason, waived := chartCIScriptWaivers[segment]; waived {
+					t.Logf("scripts/%s is referenced by .github/%s but deliberately not build-all: %s", segment, reached, reason)
+					continue
+				}
+				t.Errorf("scripts/%s is referenced by .github/%s but is neither in the build-all allowlist nor in "+
+					"chartCIScriptWaivers; a change to it would no longer build any chart version", segment, reached)
+			}
 		}
 	}
 }

--- a/scripts/deploy-camunda/matrix/plan_test.go
+++ b/scripts/deploy-camunda/matrix/plan_test.go
@@ -225,6 +225,94 @@ func TestPlanBareScriptsTokenTriggersAll(t *testing.T) {
 	}
 }
 
+func TestPlanChartDocOnlyEmptyMatrix(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/README.md charts/camunda-platform-8.10/RELEASE-NOTES.md",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	matrixJSON, err := result.MatrixJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matrixJSON != `{"include":[]}` {
+		t.Errorf("matrix = %s, want empty include", matrixJSON)
+	}
+}
+
+func TestPlanChartDocWithTemplateChangeBuildsVersion(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/README.md charts/camunda-platform-8.10/templates/common/_helpers.tpl",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 1 || got[0] != "8.10" {
+		t.Errorf("versions = %v, want [8.10]", got)
+	}
+}
+
+func TestPlanChartNotesTxtIsNotDoc(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/templates/NOTES.txt",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 1 || got[0] != "8.10" {
+		t.Errorf("versions = %v, want [8.10]", got)
+	}
+}
+
+func TestPlanToolVersionsTriggersAll(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   ".tool-versions",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != len(planActiveVersions) {
+		t.Errorf("versions = %v, want all of %v", got, planActiveVersions)
+	}
+}
+
+func TestPlanSharedE2EConfigTriggersAll(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "test/e2e/playwright.base.config.ts",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != len(planActiveVersions) {
+		t.Errorf("versions = %v, want all of %v", got, planActiveVersions)
+	}
+}
+
+func TestPlanChartScopedE2EPathOnlyTriggersChart(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   "charts/camunda-platform-8.10/test/e2e/foo.spec.ts",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 1 || got[0] != "8.10" {
+		t.Errorf("versions = %v, want [8.10]", got)
+	}
+}
+
 func TestPlanUnrelatedPathEmptyMatrix(t *testing.T) {
 	result, err := Plan(findRepoRoot(t), PlanOptions{
 		ActiveVersions: planActiveVersions,

--- a/scripts/deploy-camunda/matrix/plan_test.go
+++ b/scripts/deploy-camunda/matrix/plan_test.go
@@ -209,13 +209,53 @@ func TestPlanScriptsChangeTriggersAll(t *testing.T) {
 	}
 }
 
-func TestPlanBareScriptsTokenTriggersAll(t *testing.T) {
-	// tj-actions/changed-files with dir_names:true collapses scripts/<file>
-	// to the bare token "scripts".
+func TestPlanNonDeployScriptsNoTrigger(t *testing.T) {
 	result, err := Plan(findRepoRoot(t), PlanOptions{
 		ActiveVersions: planActiveVersions,
 		ManualTrigger:  "none",
-		ChangedFiles:   "scripts",
+		ChangedFiles:   "scripts/notify-pr-activity/main.go scripts/release-tools/pkg/harbor/client.go",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 0 {
+		t.Errorf("versions = %v, want none", got)
+	}
+}
+
+func TestPlanNonChartWorkflowNoTrigger(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   ".github/workflows/repo-pr-labeler.yaml",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != 0 {
+		t.Errorf("versions = %v, want none", got)
+	}
+}
+
+func TestPlanChartCIWorkflowTriggersAll(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   ".github/workflows/test-integration-runner.yaml",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planVersionsIn(result.Include); len(got) != len(planActiveVersions) {
+		t.Errorf("versions = %v, want all of %v", got, planActiveVersions)
+	}
+}
+
+func TestPlanActionChangeTriggersAll(t *testing.T) {
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ManualTrigger:  "none",
+		ChangedFiles:   ".github/actions/playwright-e2e-tests/action.yaml",
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6972.

### What's in this PR?

`buildAllTriggers` fired on any path under `.github/workflows`, `.github/actions`, or `scripts/`, so 37% of the last 500 merged PRs built every active chart version and 8% did so with no chart-CI-relevant file in the diff. The two coarse patterns are replaced with path-classified ones in `scripts/deploy-camunda/matrix/plan.go`:

- `chartCIWorkflows` — the `uses:` closure of `test-chart-version.yaml` (7 workflows) plus the runtime-coupled `integration-tests-gate`, `build-ci-runner-image`, `cleanup-namespace`, and the two `test-integration-*-template` workflows, which have no caller in the repo and are listed defensively.
- `deployRelevantScriptDirs` / `deployRelevantScriptFiles` — the deployer and its runtime dependencies. Everything else under `scripts/` falls through to chart-path scoping; the Go tests for `camunda-core`, `deploy-camunda`, `release-tools`, and `validate-values-schema` already run unconditionally in `test-release-tooling.yaml`.
- `.github/actions/**` and `.github/config` (minus release-please) stay build-all. 15 of 16 local actions are in the closure, so narrowing there buys nothing.

Both allowlists can silently rot in the dangerous direction — a missing entry means no chart CI at all — so `plan_allowlist_test.go` maintains them rather than a human:

- `TestChartCIWorkflowAllowlistCoversUsesClosure` re-walks `uses: ./.github/{workflows,actions}/…` from `test-chart-version.yaml` and fails if a reachable workflow is missing from `chartCIWorkflows`.
- `TestDeployRelevantScriptAllowlistCoversChartCIReferences` scans that same closure for `scripts/…` references and fails on any first path segment that is neither allowlisted nor in `chartCIScriptWaivers`. One waiver exists today: `list-chart-image-commits.sh`, whose two call sites in `test-integration-runner.yaml` are both `if: always()` with `continue-on-error: true`, so it cannot change a chart-CI result. The waiver is logged on every run, not hidden.
- Three companion tests assert every allowlist entry still exists on disk, so a rename cannot silently stop matching.

Each guard was negative-tested by removing a real entry and confirming the failure names the omitted path. They run on every PR regardless of paths, because `test-release-tooling.yaml` is deliberately unfiltered — so they fire on exactly the workflow-only PRs that would otherwise break them.

`TestPlanBareScriptsTokenTriggersAll` is removed: the bare `scripts` token was a `dir_names: true` artifact, and that option is gone as of the PR below this one.

Verified with `deploy-camunda matrix plan --active-versions "8.7 8.8 8.9 8.10"`:

| `--all-modified-files` | before | after |
|---|---|---|
| `.github/workflows/repo-pr-labeler.yaml` | all four | `[]` |
| `.github/workflows/test-integration-runner.yaml` | all four | all four |
| `.github/actions/playwright-e2e-tests/action.yaml` | all four | all four |
| `scripts/notify-pr-activity/main.go` | all four | `[]` |
| `scripts/release-tools/main.go` | all four | `[]` |
| `scripts/deploy-camunda/cmd/matrix.go` | all four | all four |

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
