### PR TITLE
test(8.10): cover two physical-tenant secret stores in secretStore unit tests

### DIFF
--- a/charts/camunda-platform-8.10/test/unit/common/secretstore_config_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/secretstore_config_test.go
@@ -201,6 +201,29 @@ func (s *secretStoreConfigTest) TestDifferentValuesInputs() {
 				s.Require().Contains(config, "path: /root/secrets")
 			},
 		},
+		{
+			Name:     "Two physical tenants render their own file store paths",
+			Template: "templates/orchestration/configmap.yaml",
+			Values: mergeValues(secretStoreBaseValues(), map[string]string{
+				"orchestration.secretStore.file.default.path":                                          "/etc/camunda/secrets/default",
+				"orchestration.secretStore.file.default.secret.existingSecret":                         "root-secret",
+				"orchestration.secretStore.physicalTenants.tenanta.file.default.path":                  "/etc/camunda/secrets/tenanta",
+				"orchestration.secretStore.physicalTenants.tenanta.file.default.secret.existingSecret": "tenanta-secret",
+				"orchestration.secretStore.physicalTenants.tenantb.file.default.path":                  "/etc/camunda/secrets/tenantb",
+				"orchestration.secretStore.physicalTenants.tenantb.file.default.secret.existingSecret": "tenantb-secret",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				config := s.applicationConfig(output)
+				s.Require().Contains(config, "physical-tenants:")
+				s.Require().Contains(config, "tenanta:")
+				s.Require().Contains(config, "tenantb:")
+				s.Require().Contains(config, "path: /etc/camunda/secrets/tenanta")
+				s.Require().Contains(config, "path: /etc/camunda/secrets/tenantb")
+				s.Require().Contains(config, "path: /etc/camunda/secrets/default")
+				s.Require().NotContains(config, "existingSecret")
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/common/secretstore_wiring_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/secretstore_wiring_test.go
@@ -301,6 +301,45 @@ func (s *secretStoreWiringTest) TestStatefulSetWiring() {
 			},
 		},
 		{
+			Name:     "Two physical tenants each mount their own Secret at their own path",
+			Template: "templates/orchestration/statefulset.yaml",
+			Values: mergeValues(secretStoreBaseValues(), map[string]string{
+				"orchestration.secretStore.file.default.path":                                          "/etc/camunda/secrets/default",
+				"orchestration.secretStore.file.default.secret.existingSecret":                         "root-secret",
+				"orchestration.secretStore.physicalTenants.tenanta.file.default.path":                  "/etc/camunda/secrets/tenanta",
+				"orchestration.secretStore.physicalTenants.tenanta.file.default.secret.existingSecret": "tenanta-secret",
+				"orchestration.secretStore.physicalTenants.tenantb.file.default.path":                  "/etc/camunda/secrets/tenantb",
+				"orchestration.secretStore.physicalTenants.tenantb.file.default.secret.existingSecret": "tenantb-secret",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var sts appsv1.StatefulSet
+				helm.UnmarshalK8SYaml(t, output, &sts)
+				volumeNameBySecret := map[string]string{}
+				for _, volume := range sts.Spec.Template.Spec.Volumes {
+					if volume.Secret != nil && strings.HasPrefix(volume.Name, "secretstore-") {
+						volumeNameBySecret[volume.Secret.SecretName] = volume.Name
+						s.Require().NotNil(volume.Secret.DefaultMode)
+						s.Require().Equal(int32(0400), *volume.Secret.DefaultMode)
+					}
+				}
+				s.Require().Len(volumeNameBySecret, 3)
+				mountPathByVolume := map[string]string{}
+				for _, mount := range sts.Spec.Template.Spec.Containers[0].VolumeMounts {
+					mountPathByVolume[mount.Name] = mount.MountPath
+				}
+				for secretName, wantPath := range map[string]string{
+					"root-secret":    "/etc/camunda/secrets/default",
+					"tenanta-secret": "/etc/camunda/secrets/tenanta",
+					"tenantb-secret": "/etc/camunda/secrets/tenantb",
+				} {
+					volumeName := volumeNameBySecret[secretName]
+					s.Require().NotEmpty(volumeName, "no volume for Secret %q", secretName)
+					s.Require().Equal(wantPath, mountPathByVolume[volumeName])
+				}
+			},
+		},
+		{
 			Name:     "Generated volume name is a DNS label for an awkward tenant id",
 			Template: "templates/orchestration/statefulset.yaml",
 			Values: mergeValues(secretStoreBaseValues(), map[string]string{


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6792.

The issue asked for a live GKE scenario proving physical-tenant secret-store isolation. That
isolation is already proven upstream — `PhysicalTenantSecretIsolationIT` (two tenants, two file
stores, same reference name, different values), `PhysicalTenantSecretsOverlayTest` (overlay
precedence), `SecretStoreConfigurationTest` (which binds the exact property strings this chart
renders, for two tenants), and the existing `secretstore-file` scenario (same mount helper, same
`0400`, same resolve endpoint). The full coverage map and a one-off GKE validation record for a
two-tenant deployment are on #6792.

What was left uncovered is chart-side only, and this PR closes it.

Every existing `orchestration.secretStore.physicalTenants` unit test uses exactly one non-default
tenant, so nothing pins the rendering when two tenants are configured at once. `renderConfig`
builds each tenant's effective store with `mergeOverwrite (deepCopy $root) $tenantOverride`; with a
single tenant in every test, dropping the `deepCopy` would leak one tenant's fields into another
undetected.

### What's in this PR?

- `secretstore_wiring_test.go`: root store plus `tenanta` and `tenantb` at sibling paths render three
  distinct Secret volumes, each mounted at its own path with `defaultMode: 0400`, with no dedup
  collapse.
- `secretstore_config_test.go`: the same values render both
  `camunda.physical-tenants.{tenanta,tenantb}.secrets.stores.file.default.path` alongside the root
  store, and no chart-only key (`existingSecret`) leaks into the application config.

Validated on GKE separately: a two-tenant deployment of this shape starts and each tenant resolves
the same reference name from its own mounted Secret. Details are on #6792.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
