### PR TITLE
fix: warn that the bundled Keycloak image line is frozen and affected by CVE-2026-18963

### DIFF
--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -223,6 +223,21 @@ The following values inside your values.yaml need to be set but were not:
       {{- end }}
     {{- end }}
   {{- end }}
+
+  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
+       semverCompare receives a parseable version. */}}
+  {{- if .Values.identityKeycloak.enabled }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+      {{- $warningMessage := printf "%s %s %s %s"
+          "[camunda][warning]"
+          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+      -}}
+      {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 

--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -232,8 +232,8 @@ The following values inside your values.yaml need to be set but were not:
       {{- $warningMessage := printf "%s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
@@ -67,13 +67,77 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 		},
 		{
 			Name: "TestWarningsConfigMapAbsentWhenNoWarnings",
+			// identityKeycloak is enabled by default on 8.7 and its image is affected by
+			// CVE-2026-18963, so it must be disabled for a warning-free render.
 			Values: map[string]string{
 				"global.testDeprecationFlags.existingSecretsMustBeSet": "false",
+				"identityKeycloak.enabled":                             "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				// With no active warnings the helper renders nothing, so --show-only finds no manifest.
 				s.Require().Error(err)
 				s.Require().NotContains(output, "kind: ConfigMap")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestAffectedVersionWarns",
+			Values: map[string]string{
+				"identityKeycloak.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestBitnamiRevisionSuffixIsParsed",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.3.3-debian-12-r0-2026-08-27-001",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestFixedVersionDoesNotWarn",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.2",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestUnparseableTagDoesNotWarn",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "latest",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestDisabledKeycloakDoesNotWarn",
+			Values: map[string]string{
+				"identityKeycloak.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -337,6 +337,21 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
 
   {{- end }}
+
+  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
+       semverCompare receives a parseable version. */}}
+  {{- if .Values.identityKeycloak.enabled }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+      {{- $warningMessage := printf "%s %s %s %s"
+          "[camunda][warning]"
+          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+      -}}
+      {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -346,8 +346,8 @@ The following values inside your values.yaml need to be set but were not:
       {{- $warningMessage := printf "%s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -90,3 +90,69 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestAffectedVersionWarns",
+			Values: map[string]string{
+				"identity.enabled":         "true",
+				"identityKeycloak.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestBitnamiRevisionSuffixIsParsed",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.3.3-debian-12-r0-2026-08-27-001",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestFixedVersionDoesNotWarn",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.2",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestUnparseableTagDoesNotWarn",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "latest",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestDisabledKeycloakDoesNotWarn",
+			Values: map[string]string{
+				"identity.enabled":         "true",
+				"identityKeycloak.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -464,6 +464,21 @@ The following values inside your values.yaml need to be set but were not:
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}
   {{- end }}
+
+  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
+       semverCompare receives a parseable version. */}}
+  {{- if .Values.identityKeycloak.enabled }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+      {{- $warningMessage := printf "%s %s %s %s"
+          "[camunda][warning]"
+          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+      -}}
+      {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -473,8 +473,8 @@ The following values inside your values.yaml need to be set but were not:
       {{- $warningMessage := printf "%s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -139,6 +139,68 @@ func (s *ConfigMapWarningsTemplateTest) TestLegacyExporterTruststoreConflict() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
+	baseValues := map[string]string{
+		"orchestration.data.secondaryStorage.type": "elasticsearch",
+		"identity.enabled":                         "true",
+		"identityKeycloak.enabled":                 "true",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestAffectedVersionWarns",
+			Values: baseValues,
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestBitnamiRevisionSuffixIsParsed",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "26.3.3-debian-12-r0-2026-08-27-001",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestFixedVersionDoesNotWarn",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "26.7.2",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestUnparseableTagDoesNotWarn",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "latest",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestDisabledKeycloakDoesNotWarn",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.enabled": "false",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func mergeMaps(base map[string]string, overrides map[string]string) map[string]string {
 	merged := make(map[string]string, len(base)+len(overrides))
 	for key, value := range base {


### PR DESCRIPTION
### Which problem does the PR fix?

Refs #6987.

The Community Edition default for the bundled Keycloak subchart is `camunda/keycloak:26.3.3` in 8.7, 8.8 and 8.9. CVE-2026-18963 is a reported critical password-reset flaw in Keycloak that can lead to account takeover, fixed in Keycloak 26.7.2 — so that default is affected.

The tag cannot be bumped, because the chart pins a tag line that has been discontinued. Per [`keycloak-26/bases.yml`](https://github.com/camunda/keycloak/blob/main/keycloak-26/bases.yml) in `camunda/keycloak`:

| Tag line | Base image | State |
| --- | --- | --- |
| unprefixed + `bitnami-*` | `docker.io/bitnamilegacy/keycloak:26.3.3-debian-12-r0` | frozen |
| `quay-*` / `quay-optimized-*` / `latest` | `quay.io/keycloak/keycloak:26.7.2-1` | maintained |
| `bitnami-ee-*` (enterprise registry) | `registry.camunda.cloud/vendor-ee/keycloak:26.7.2-debian-12-r1` | maintained |

`keycloak-26/Dockerfile` says so outright: *"DEPRECATED — Bitnami-based Keycloak image. […] This variant is frozen: its AWS Advanced JDBC Wrapper stays at 2.6.8 […] and is no longer tracked by Renovate."*

So the weekly `26.3.3-debian-12-r0-<date>` tags are rebuilds of a frozen base, not version bumps. A fixed image does exist — `quay-26.7.2` and `quay-optimized-26.7.2`, both published 2026-08-27 — just not on the line the chart points at.

Renovate is not misreading anything: `identityKeycloak.image.tag` carries no annotation, so it is tracked by the `helm-values` manager against `docker.io/camunda/keycloak`, where `26.3.3` genuinely is the newest tag. `camunda/infraex-common-config` (`default.json5`) documents the sanctioned annotation for this image and it targets the quay line.

Enterprise is already covered — `keycloak-ee/keycloak` went to `26.7.2` in #6930.

### What's in this PR?

A render-time warning, so affected users are told they are on a dead tag line instead of silently running an affected Keycloak while waiting for a bump that will never arrive.

The warning is declared in the existing `camunda.constraints.warnings` define (`templates/camunda/constraints.tpl` on 8.7, `templates/common/constraints.tpl` on 8.8/8.9), which reaches both channels already wired for it: `helm install`/`helm upgrade` output via `NOTES.txt`, and the `<release>-warnings` ConfigMap on the GitOps path.

Two decisions worth calling out:

- **Version-gated, not unconditional.** It fires only when `identityKeycloak.enabled` and the resolved version is `< 26.7.2`. It stays silent for anyone who already overrode `identityKeycloak.image`, including onto a `quay-*` tag, which does not parse as a bare `X.Y.Z` and so reads as "migrated".
- **`regexFind` before `semverCompare`.** Tags carry a Bitnami revision or rebuild-date suffix (`26.3.3-debian-12-r0-2026-08-27-001`), and `semverCompare` errors on input it cannot parse. Trimming to the leading `X.Y.Z` catches those dated rebuild tags and keeps a non-semver tag from breaking the render.

Deliberately **not** done: repointing the default at the quay images. They are not a drop-in for `identityKeycloak`, which is the Bitnami `keycloak-24` subchart — different paths (`/opt/keycloak/…` vs `/opt/bitnami/keycloak/…`), different environment contract (`KC_BOOTSTRAP_ADMIN_USERNAME` / `KC_DB_*` vs `KEYCLOAK_ADMIN` plus the Bitnami variables), and an explicit `start` command. `charts/internal-keycloak-26/values.yaml` already documents that split in its `command` parameter. Choosing between adopting the quay images and declaring external Keycloak the only supported path for 8.7–8.9 is tracked in #6987.

8.10 needs no change — the bundled subchart was removed in #6146. 8.9 already warns that Bitnami-based subcharts are deprecated; 8.7 and 8.8 carry no such warning, which is where this adds the most.

Tests: a `TestBundledKeycloakCveWarning` case matrix per version (affected version warns, Bitnami revision suffix parsed, 26.7.2 silent, unparseable tag silent and render-safe, disabled subchart silent). 8.7 enables `identityKeycloak` by default, so its existing warning-free render case now disables the subchart explicitly.

Verified: `make helm.lint` clean on all three charts; `make go.test` for 8.7/8.8/8.9 shows no new failures (the `TestGolden*Defaults` failures present locally reproduce identically on `main`).

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
