### PR TITLE
fix: warn that the bundled Keycloak image line is frozen and affected by CVE-2026-18963

### DIFF
--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -224,19 +224,36 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
   {{- end }}
 
-  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
-       semverCompare receives a parseable version. */}}
+  {{/* CVE-2026-18963 is fixed in Keycloak 26.7.2. regexFind pulls the version out of a
+       tag that may carry a "bitnami-" or "quay-" prefix and a "-debian-12-rN" or
+       rebuild-date suffix, so semverCompare receives a parseable version. The moving
+       aliases of the Bitnami line ("26", "bitnami-26", "bitnami-latest",
+       "latest-bitnami") carry no version at all, yet resolve to a frozen bitnamilegacy
+       build that is affected and stays affected, so they are matched by name:
+       https://github.com/camunda/keycloak/blob/main/.github/workflows/build-images.yml */}}
   {{- if .Values.identityKeycloak.enabled }}
     {{- $keycloakImage := .Values.identityKeycloak.image }}
-    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" (($keycloakImage).tag | toString) }}
-    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+    {{- $keycloakTag := (($keycloakImage).tag | toString) }}
+    {{- $keycloakVersion := regexFind "[0-9]+\\.[0-9]+\\.[0-9]+" $keycloakTag }}
+    {{- /* On "camunda/keycloak" the "quay-*" tags and the plain "latest" alias track
+           upstream Keycloak and are still maintained; every other tag of that repository
+           belongs to the frozen Bitnami line. */}}
+    {{- $onFrozenLine := and (eq (($keycloakImage).repository | toString) "camunda/keycloak")
+        (not (hasPrefix "quay-" $keycloakTag)) (ne $keycloakTag "latest") }}
+    {{- $frozenAlias := and $onFrozenLine (not $keycloakVersion)
+        (regexMatch "^(bitnami-)?[0-9]+$|^(bitnami-latest|latest-bitnami)$" $keycloakTag) }}
+    {{- if or $frozenAlias (and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion)) }}
+      {{- $affectedImage := printf "is pinned to %s, which is" $keycloakVersion }}
+      {{- if $frozenAlias }}
+        {{- $affectedImage = printf "uses the moving tag \"%s\", which resolves to a frozen Bitnami build that is" $keycloakTag }}
+      {{- end }}
       {{- $frozenLineNote := "" }}
-      {{- if eq (($keycloakImage).repository | toString) "camunda/keycloak" }}
+      {{- if $onFrozenLine }}
         {{- $frozenLineNote = " The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix." }}
       {{- end }}
       {{- $warningMessage := printf "%s %s%s %s %s"
           "[camunda][warning]"
-          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          (printf "SECURITY: the bundled Keycloak image %s affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $affectedImage)
           $frozenLineNote
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
           "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins a patched Bitnami-based \"keycloak-ee/keycloak\" image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"

--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -223,6 +223,21 @@ The following values inside your values.yaml need to be set but were not:
       {{- end }}
     {{- end }}
   {{- end }}
+
+  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
+       semverCompare receives a parseable version. */}}
+  {{- if .Values.identityKeycloak.enabled }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+      {{- $warningMessage := printf "%s %s %s %s"
+          "[camunda][warning]"
+          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+      -}}
+      {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 

--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -234,7 +234,7 @@ The following values inside your values.yaml need to be set but were not:
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
           "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
-          "Enterprise customers can instead point \"identityKeycloak.image\" at \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\", which is Bitnami-based and drop-in compatible with this subchart. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins the Bitnami-based \"keycloak-ee/keycloak\" 26.7.2 image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -227,14 +227,19 @@ The following values inside your values.yaml need to be set but were not:
   {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
        semverCompare receives a parseable version. */}}
   {{- if .Values.identityKeycloak.enabled }}
-    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- $keycloakImage := .Values.identityKeycloak.image }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" (($keycloakImage).tag | toString) }}
     {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
-      {{- $warningMessage := printf "%s %s %s %s %s"
+      {{- $frozenLineNote := "" }}
+      {{- if eq (($keycloakImage).repository | toString) "camunda/keycloak" }}
+        {{- $frozenLineNote = " The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix." }}
+      {{- end }}
+      {{- $warningMessage := printf "%s %s%s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
+          $frozenLineNote
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
-          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins the Bitnami-based \"keycloak-ee/keycloak\" 26.7.2 image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins a patched Bitnami-based \"keycloak-ee/keycloak\" image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -232,8 +232,8 @@ The following values inside your values.yaml need to be set but were not:
       {{- $warningMessage := printf "%s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -229,11 +229,12 @@ The following values inside your values.yaml need to be set but were not:
   {{- if .Values.identityKeycloak.enabled }}
     {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
     {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
-      {{- $warningMessage := printf "%s %s %s %s"
+      {{- $warningMessage := printf "%s %s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
+          "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
+          "Enterprise customers can instead point \"identityKeycloak.image\" at \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\", which is Bitnami-based and drop-in compatible with this subchart. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
@@ -112,6 +112,16 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestFixedVersionWithBitnamiSuffixDoesNotWarn",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.2-debian-12-r0",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestFixedVersionDoesNotWarn",
 			Values: map[string]string{
 				"identityKeycloak.enabled":   "true",

--- a/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
@@ -67,13 +67,77 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 		},
 		{
 			Name: "TestWarningsConfigMapAbsentWhenNoWarnings",
+			// identityKeycloak is enabled by default on 8.7 and its image is affected by
+			// CVE-2026-18963, so it must be disabled for a warning-free render.
 			Values: map[string]string{
 				"global.testDeprecationFlags.existingSecretsMustBeSet": "false",
+				"identityKeycloak.enabled":                             "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				// With no active warnings the helper renders nothing, so --show-only finds no manifest.
 				s.Require().Error(err)
 				s.Require().NotContains(output, "kind: ConfigMap")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestAffectedVersionWarns",
+			Values: map[string]string{
+				"identityKeycloak.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestBitnamiRevisionSuffixIsParsed",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.3.3-debian-12-r0-2026-08-27-001",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestFixedVersionDoesNotWarn",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.2",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestUnparseableTagDoesNotWarn",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "latest",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestDisabledKeycloakDoesNotWarn",
+			Values: map[string]string{
+				"identityKeycloak.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
@@ -112,6 +112,19 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestLastAffectedVersionWarns",
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestFixedVersionWithBitnamiSuffixDoesNotWarn",
 			Values: map[string]string{
 				"identityKeycloak.enabled":   "true",

--- a/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
@@ -112,6 +112,21 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestOverriddenRepositoryOmitsFrozenLineClaim",
+			Values: map[string]string{
+				"identityKeycloak.enabled":          "true",
+				"identityKeycloak.image.repository": "acme/keycloak",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				warnings := configmap.Data["warnings"]
+				s.Require().Contains(warnings, "CVE-2026-18963")
+				s.Require().NotContains(warnings, "frozen on the discontinued bitnamilegacy base")
+			},
+		},
+		{
 			Name: "TestLastAffectedVersionWarns",
 			Values: map[string]string{
 				"identityKeycloak.enabled":   "true",
@@ -131,6 +146,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "26.7.2-debian-12-r0",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -141,6 +162,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "26.7.2",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -151,15 +178,33 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "latest",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
 		{
 			Name: "TestDisabledKeycloakDoesNotWarn",
+			// Disabling the bundled subchart requires pointing the chart at an external
+			// Keycloak; without a URL the render fails in zeebe-gateway and the case would
+			// pass without ever exercising the warning.
 			Values: map[string]string{
-				"identityKeycloak.enabled": "false",
+				"identityKeycloak.enabled":              "false",
+				"global.identity.keycloak.url.protocol": "https",
+				"global.identity.keycloak.url.host":     "keycloak.example.com",
+				"global.identity.keycloak.url.port":     "443",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},

--- a/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
@@ -112,6 +112,68 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestPrefixedFrozenTagWarns",
+			// The upstream publish workflow also tags the frozen build as "bitnami-<version>".
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "bitnami-26.3.3",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestMovingFrozenAliasWarns",
+			// "bitnami-26" carries no version, but it resolves to the frozen 26.3.3 build.
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "bitnami-26",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				warnings := configmap.Data["warnings"]
+				s.Require().Contains(warnings, "CVE-2026-18963")
+				s.Require().Contains(warnings, `uses the moving tag "bitnami-26"`)
+				s.Require().Contains(warnings, "frozen on the discontinued bitnamilegacy base")
+			},
+		},
+		{
+			Name: "TestLatestBitnamiAliasWarns",
+			// The frozen line also moves under "bitnami-latest" and "latest-bitnami".
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "latest-bitnami",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestMaintainedQuayAliasDoesNotWarn",
+			// The "quay-*" tags track upstream Keycloak and are still maintained.
+			Values: map[string]string{
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "quay-26",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestOverriddenRepositoryOmitsFrozenLineClaim",
 			Values: map[string]string{
 				"identityKeycloak.enabled":          "true",
@@ -172,7 +234,7 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
-			Name: "TestUnparseableTagDoesNotWarn",
+			Name: "TestMaintainedLatestTagDoesNotWarn",
 			Values: map[string]string{
 				"identityKeycloak.enabled":   "true",
 				"identityKeycloak.image.tag": "latest",

--- a/charts/camunda-platform-8.7/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.7/test/unit/common/notes_test.go
@@ -43,3 +43,24 @@ func TestNotesTemplate(t *testing.T) {
 	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }
+
+func TestNotesSurfacesBundledKeycloakCveWarning(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "keycloak-cve-notes-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.enabled=true",
+		"--set", "identityKeycloak.enabled=true",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, "CVE-2026-18963")
+}

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -341,14 +341,19 @@ The following values inside your values.yaml need to be set but were not:
   {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
        semverCompare receives a parseable version. */}}
   {{- if .Values.identityKeycloak.enabled }}
-    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- $keycloakImage := .Values.identityKeycloak.image }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" (($keycloakImage).tag | toString) }}
     {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
-      {{- $warningMessage := printf "%s %s %s %s %s"
+      {{- $frozenLineNote := "" }}
+      {{- if eq (($keycloakImage).repository | toString) "camunda/keycloak" }}
+        {{- $frozenLineNote = " The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix." }}
+      {{- end }}
+      {{- $warningMessage := printf "%s %s%s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
+          $frozenLineNote
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
-          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins the Bitnami-based \"keycloak-ee/keycloak\" 26.7.2 image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins a patched Bitnami-based \"keycloak-ee/keycloak\" image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -338,19 +338,36 @@ The following values inside your values.yaml need to be set but were not:
 
   {{- end }}
 
-  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
-       semverCompare receives a parseable version. */}}
+  {{/* CVE-2026-18963 is fixed in Keycloak 26.7.2. regexFind pulls the version out of a
+       tag that may carry a "bitnami-" or "quay-" prefix and a "-debian-12-rN" or
+       rebuild-date suffix, so semverCompare receives a parseable version. The moving
+       aliases of the Bitnami line ("26", "bitnami-26", "bitnami-latest",
+       "latest-bitnami") carry no version at all, yet resolve to a frozen bitnamilegacy
+       build that is affected and stays affected, so they are matched by name:
+       https://github.com/camunda/keycloak/blob/main/.github/workflows/build-images.yml */}}
   {{- if .Values.identityKeycloak.enabled }}
     {{- $keycloakImage := .Values.identityKeycloak.image }}
-    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" (($keycloakImage).tag | toString) }}
-    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+    {{- $keycloakTag := (($keycloakImage).tag | toString) }}
+    {{- $keycloakVersion := regexFind "[0-9]+\\.[0-9]+\\.[0-9]+" $keycloakTag }}
+    {{- /* On "camunda/keycloak" the "quay-*" tags and the plain "latest" alias track
+           upstream Keycloak and are still maintained; every other tag of that repository
+           belongs to the frozen Bitnami line. */}}
+    {{- $onFrozenLine := and (eq (($keycloakImage).repository | toString) "camunda/keycloak")
+        (not (hasPrefix "quay-" $keycloakTag)) (ne $keycloakTag "latest") }}
+    {{- $frozenAlias := and $onFrozenLine (not $keycloakVersion)
+        (regexMatch "^(bitnami-)?[0-9]+$|^(bitnami-latest|latest-bitnami)$" $keycloakTag) }}
+    {{- if or $frozenAlias (and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion)) }}
+      {{- $affectedImage := printf "is pinned to %s, which is" $keycloakVersion }}
+      {{- if $frozenAlias }}
+        {{- $affectedImage = printf "uses the moving tag \"%s\", which resolves to a frozen Bitnami build that is" $keycloakTag }}
+      {{- end }}
       {{- $frozenLineNote := "" }}
-      {{- if eq (($keycloakImage).repository | toString) "camunda/keycloak" }}
+      {{- if $onFrozenLine }}
         {{- $frozenLineNote = " The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix." }}
       {{- end }}
       {{- $warningMessage := printf "%s %s%s %s %s"
           "[camunda][warning]"
-          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          (printf "SECURITY: the bundled Keycloak image %s affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $affectedImage)
           $frozenLineNote
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
           "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins a patched Bitnami-based \"keycloak-ee/keycloak\" image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -343,11 +343,12 @@ The following values inside your values.yaml need to be set but were not:
   {{- if .Values.identityKeycloak.enabled }}
     {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
     {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
-      {{- $warningMessage := printf "%s %s %s %s"
+      {{- $warningMessage := printf "%s %s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
+          "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
+          "Enterprise customers can instead point \"identityKeycloak.image\" at \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\", which is Bitnami-based and drop-in compatible with this subchart. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -337,6 +337,21 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
 
   {{- end }}
+
+  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
+       semverCompare receives a parseable version. */}}
+  {{- if .Values.identityKeycloak.enabled }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+      {{- $warningMessage := printf "%s %s %s %s"
+          "[camunda][warning]"
+          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+      -}}
+      {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -348,7 +348,7 @@ The following values inside your values.yaml need to be set but were not:
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
           "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
-          "Enterprise customers can instead point \"identityKeycloak.image\" at \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\", which is Bitnami-based and drop-in compatible with this subchart. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins the Bitnami-based \"keycloak-ee/keycloak\" 26.7.2 image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -346,8 +346,8 @@ The following values inside your values.yaml need to be set but were not:
       {{- $warningMessage := printf "%s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -121,6 +121,72 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestPrefixedFrozenTagWarns",
+			// The upstream publish workflow also tags the frozen build as "bitnami-<version>".
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "bitnami-26.3.3",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestMovingFrozenAliasWarns",
+			// "bitnami-26" carries no version, but it resolves to the frozen 26.3.3 build.
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "bitnami-26",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				warnings := configmap.Data["warnings"]
+				s.Require().Contains(warnings, "CVE-2026-18963")
+				s.Require().Contains(warnings, `uses the moving tag "bitnami-26"`)
+				s.Require().Contains(warnings, "frozen on the discontinued bitnamilegacy base")
+			},
+		},
+		{
+			Name: "TestLatestBitnamiAliasWarns",
+			// The frozen line also moves under "bitnami-latest" and "latest-bitnami".
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "latest-bitnami",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestMaintainedQuayAliasDoesNotWarn",
+			// The "quay-*" tags track upstream Keycloak and are still maintained.
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "quay-26",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestOverriddenRepositoryOmitsFrozenLineClaim",
 			Values: map[string]string{
 				"identity.enabled":                  "true",
@@ -185,7 +251,7 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
-			Name: "TestUnparseableTagDoesNotWarn",
+			Name: "TestMaintainedLatestTagDoesNotWarn",
 			Values: map[string]string{
 				"identity.enabled":           "true",
 				"identityKeycloak.enabled":   "true",

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -121,6 +121,22 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestOverriddenRepositoryOmitsFrozenLineClaim",
+			Values: map[string]string{
+				"identity.enabled":                  "true",
+				"identityKeycloak.enabled":          "true",
+				"identityKeycloak.image.repository": "acme/keycloak",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				warnings := configmap.Data["warnings"]
+				s.Require().Contains(warnings, "CVE-2026-18963")
+				s.Require().NotContains(warnings, "frozen on the discontinued bitnamilegacy base")
+			},
+		},
+		{
 			Name: "TestLastAffectedVersionWarns",
 			Values: map[string]string{
 				"identity.enabled":           "true",
@@ -142,6 +158,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "26.7.2-debian-12-r0",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -153,6 +175,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "26.7.2",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -164,6 +192,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "latest",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -174,6 +208,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.enabled": "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -90,3 +90,69 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestAffectedVersionWarns",
+			Values: map[string]string{
+				"identity.enabled":         "true",
+				"identityKeycloak.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestBitnamiRevisionSuffixIsParsed",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.3.3-debian-12-r0-2026-08-27-001",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestFixedVersionDoesNotWarn",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.2",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestUnparseableTagDoesNotWarn",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "latest",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestDisabledKeycloakDoesNotWarn",
+			Values: map[string]string{
+				"identity.enabled":         "true",
+				"identityKeycloak.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -121,6 +121,20 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestLastAffectedVersionWarns",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestFixedVersionWithBitnamiSuffixDoesNotWarn",
 			Values: map[string]string{
 				"identity.enabled":           "true",

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -121,6 +121,17 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestFixedVersionWithBitnamiSuffixDoesNotWarn",
+			Values: map[string]string{
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+				"identityKeycloak.image.tag": "26.7.2-debian-12-r0",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestFixedVersionDoesNotWarn",
 			Values: map[string]string{
 				"identity.enabled":           "true",

--- a/charts/camunda-platform-8.8/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/notes_test.go
@@ -43,3 +43,24 @@ func TestNotesTemplate(t *testing.T) {
 	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }
+
+func TestNotesSurfacesBundledKeycloakCveWarning(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "keycloak-cve-notes-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.enabled=true",
+		"--set", "identityKeycloak.enabled=true",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, "CVE-2026-18963")
+}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -475,7 +475,7 @@ The following values inside your values.yaml need to be set but were not:
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
           "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
-          "Enterprise customers can instead point \"identityKeycloak.image\" at \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\", which is Bitnami-based and drop-in compatible with this subchart. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins the Bitnami-based \"keycloak-ee/keycloak\" 26.7.2 image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -470,11 +470,12 @@ The following values inside your values.yaml need to be set but were not:
   {{- if .Values.identityKeycloak.enabled }}
     {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
     {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
-      {{- $warningMessage := printf "%s %s %s %s"
+      {{- $warningMessage := printf "%s %s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
+          "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
+          "Enterprise customers can instead point \"identityKeycloak.image\" at \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\", which is Bitnami-based and drop-in compatible with this subchart. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -468,14 +468,19 @@ The following values inside your values.yaml need to be set but were not:
   {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
        semverCompare receives a parseable version. */}}
   {{- if .Values.identityKeycloak.enabled }}
-    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- $keycloakImage := .Values.identityKeycloak.image }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" (($keycloakImage).tag | toString) }}
     {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
-      {{- $warningMessage := printf "%s %s %s %s %s"
+      {{- $frozenLineNote := "" }}
+      {{- if eq (($keycloakImage).repository | toString) "camunda/keycloak" }}
+        {{- $frozenLineNote = " The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix." }}
+      {{- end }}
+      {{- $warningMessage := printf "%s %s%s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix."
+          $frozenLineNote
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
-          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins the Bitnami-based \"keycloak-ee/keycloak\" 26.7.2 image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins a patched Bitnami-based \"keycloak-ee/keycloak\" image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -464,6 +464,21 @@ The following values inside your values.yaml need to be set but were not:
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}
   {{- end }}
+
+  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
+       semverCompare receives a parseable version. */}}
+  {{- if .Values.identityKeycloak.enabled }}
+    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" ((.Values.identityKeycloak.image).tag | toString) }}
+    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+      {{- $warningMessage := printf "%s %s %s %s"
+          "[camunda][warning]"
+          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+      -}}
+      {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -473,8 +473,8 @@ The following values inside your values.yaml need to be set but were not:
       {{- $warningMessage := printf "%s %s %s %s"
           "[camunda][warning]"
           (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
-          "No fixed \"camunda/keycloak\" image is published yet, so the chart default cannot be raised. Tracking issue: https://github.com/camunda/camunda-platform-helm/issues/6987"
-          "Override \"identityKeycloak.image\" with a Keycloak 26.7.2 or later build (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"), or use an externally managed Keycloak."
+          "The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"
+          "Migrate to an externally managed Keycloak, or to the maintained \"camunda/keycloak:quay-*\" images (Enterprise: \"registry.camunda.cloud/keycloak-ee/keycloak:26.7.2\"). The quay images follow upstream Keycloak conventions and are not a drop-in replacement for this Bitnami-based subchart."
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -465,19 +465,36 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
   {{- end }}
 
-  {{/* regexFind trims the Bitnami "-debian-12-rN" / rebuild-date suffix so
-       semverCompare receives a parseable version. */}}
+  {{/* CVE-2026-18963 is fixed in Keycloak 26.7.2. regexFind pulls the version out of a
+       tag that may carry a "bitnami-" or "quay-" prefix and a "-debian-12-rN" or
+       rebuild-date suffix, so semverCompare receives a parseable version. The moving
+       aliases of the Bitnami line ("26", "bitnami-26", "bitnami-latest",
+       "latest-bitnami") carry no version at all, yet resolve to a frozen bitnamilegacy
+       build that is affected and stays affected, so they are matched by name:
+       https://github.com/camunda/keycloak/blob/main/.github/workflows/build-images.yml */}}
   {{- if .Values.identityKeycloak.enabled }}
     {{- $keycloakImage := .Values.identityKeycloak.image }}
-    {{- $keycloakVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" (($keycloakImage).tag | toString) }}
-    {{- if and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion) }}
+    {{- $keycloakTag := (($keycloakImage).tag | toString) }}
+    {{- $keycloakVersion := regexFind "[0-9]+\\.[0-9]+\\.[0-9]+" $keycloakTag }}
+    {{- /* On "camunda/keycloak" the "quay-*" tags and the plain "latest" alias track
+           upstream Keycloak and are still maintained; every other tag of that repository
+           belongs to the frozen Bitnami line. */}}
+    {{- $onFrozenLine := and (eq (($keycloakImage).repository | toString) "camunda/keycloak")
+        (not (hasPrefix "quay-" $keycloakTag)) (ne $keycloakTag "latest") }}
+    {{- $frozenAlias := and $onFrozenLine (not $keycloakVersion)
+        (regexMatch "^(bitnami-)?[0-9]+$|^(bitnami-latest|latest-bitnami)$" $keycloakTag) }}
+    {{- if or $frozenAlias (and $keycloakVersion (semverCompare "<26.7.2" $keycloakVersion)) }}
+      {{- $affectedImage := printf "is pinned to %s, which is" $keycloakVersion }}
+      {{- if $frozenAlias }}
+        {{- $affectedImage = printf "uses the moving tag \"%s\", which resolves to a frozen Bitnami build that is" $keycloakTag }}
+      {{- end }}
       {{- $frozenLineNote := "" }}
-      {{- if eq (($keycloakImage).repository | toString) "camunda/keycloak" }}
+      {{- if $onFrozenLine }}
         {{- $frozenLineNote = " The Bitnami-based \"camunda/keycloak\" tags this chart defaults to are frozen on the discontinued bitnamilegacy base and will not receive the fix." }}
       {{- end }}
       {{- $warningMessage := printf "%s %s%s %s %s"
           "[camunda][warning]"
-          (printf "SECURITY: the bundled Keycloak image is pinned to %s, which is affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $keycloakVersion)
+          (printf "SECURITY: the bundled Keycloak image %s affected by CVE-2026-18963, a critical password-reset flaw enabling account takeover. It is fixed in Keycloak 26.7.2." $affectedImage)
           $frozenLineNote
           "Recommended: migrate this subchart to the Keycloak Operator, which replaces its StatefulSet: https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
           "Enterprise customers can instead deploy with the chart's \"values-enterprise.yaml\", which pins a patched Bitnami-based \"keycloak-ee/keycloak\" image along with the registry pull secret it requires. Details: https://github.com/camunda/camunda-platform-helm/issues/6987"

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -139,6 +139,68 @@ func (s *ConfigMapWarningsTemplateTest) TestLegacyExporterTruststoreConflict() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
+	baseValues := map[string]string{
+		"orchestration.data.secondaryStorage.type": "elasticsearch",
+		"identity.enabled":                         "true",
+		"identityKeycloak.enabled":                 "true",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestAffectedVersionWarns",
+			Values: baseValues,
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestBitnamiRevisionSuffixIsParsed",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "26.3.3-debian-12-r0-2026-08-27-001",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestFixedVersionDoesNotWarn",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "26.7.2",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestUnparseableTagDoesNotWarn",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "latest",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestDisabledKeycloakDoesNotWarn",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.enabled": "false",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func mergeMaps(base map[string]string, overrides map[string]string) map[string]string {
 	merged := make(map[string]string, len(base)+len(overrides))
 	for key, value := range base {

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -170,6 +170,15 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestFixedVersionWithBitnamiSuffixDoesNotWarn",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "26.7.2-debian-12-r0",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestFixedVersionDoesNotWarn",
 			Values: mergeMaps(baseValues, map[string]string{
 				"identityKeycloak.image.tag": "26.7.2",

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -170,6 +170,64 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestPrefixedFrozenTagWarns",
+			// The upstream publish workflow also tags the frozen build as "bitnami-<version>".
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "bitnami-26.3.3",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestMovingFrozenAliasWarns",
+			// "bitnami-26" carries no version, but it resolves to the frozen 26.3.3 build.
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "bitnami-26",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				warnings := configmap.Data["warnings"]
+				s.Require().Contains(warnings, "CVE-2026-18963")
+				s.Require().Contains(warnings, `uses the moving tag "bitnami-26"`)
+				s.Require().Contains(warnings, "frozen on the discontinued bitnamilegacy base")
+			},
+		},
+		{
+			Name: "TestLatestBitnamiAliasWarns",
+			// The frozen line also moves under "bitnami-latest" and "latest-bitnami".
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "latest-bitnami",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
+			Name: "TestMaintainedQuayAliasDoesNotWarn",
+			// The "quay-*" tags track upstream Keycloak and are still maintained.
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "quay-26",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
+				s.Require().NotContains(output, "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestOverriddenRepositoryOmitsFrozenLineClaim",
 			Values: mergeMaps(baseValues, map[string]string{
 				"identityKeycloak.image.repository": "acme/keycloak",
@@ -226,7 +284,7 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
-			Name: "TestUnparseableTagDoesNotWarn",
+			Name: "TestMaintainedLatestTagDoesNotWarn",
 			Values: mergeMaps(baseValues, map[string]string{
 				"identityKeycloak.image.tag": "latest",
 			}),

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -170,6 +170,20 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestOverriddenRepositoryOmitsFrozenLineClaim",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.repository": "acme/keycloak",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				warnings := configmap.Data["warnings"]
+				s.Require().Contains(warnings, "CVE-2026-18963")
+				s.Require().NotContains(warnings, "frozen on the discontinued bitnamilegacy base")
+			},
+		},
+		{
 			Name: "TestLastAffectedVersionWarns",
 			Values: mergeMaps(baseValues, map[string]string{
 				"identityKeycloak.image.tag": "26.7.1",
@@ -187,6 +201,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "26.7.2-debian-12-r0",
 			}),
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -196,6 +216,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "26.7.2",
 			}),
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -205,6 +231,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.image.tag": "latest",
 			}),
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},
@@ -214,6 +246,12 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 				"identityKeycloak.enabled": "false",
 			}),
 			Verifier: func(t *testing.T, output string, err error) {
+				// A no-warning render produces no manifest, which --show-only reports as a
+				// missing template; any other error means the render broke for an unrelated
+				// reason and must not pass as "no warning".
+				if err != nil {
+					s.Require().Contains(err.Error(), "could not find template")
+				}
 				s.Require().NotContains(output, "CVE-2026-18963")
 			},
 		},

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -170,6 +170,18 @@ func (s *ConfigMapWarningsTemplateTest) TestBundledKeycloakCveWarning() {
 			},
 		},
 		{
+			Name: "TestLastAffectedVersionWarns",
+			Values: mergeMaps(baseValues, map[string]string{
+				"identityKeycloak.image.tag": "26.7.1",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "CVE-2026-18963")
+			},
+		},
+		{
 			Name: "TestFixedVersionWithBitnamiSuffixDoesNotWarn",
 			Values: mergeMaps(baseValues, map[string]string{
 				"identityKeycloak.image.tag": "26.7.2-debian-12-r0",

--- a/charts/camunda-platform-8.9/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/notes_test.go
@@ -90,3 +90,24 @@ func TestNotesTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestNotesSurfacesBundledKeycloakCveWarning(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "keycloak-cve-notes-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.enabled=true",
+		"--set", "identityKeycloak.enabled=true",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, "CVE-2026-18963")
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Refs #6987. Recreates #6988, which was closed.

The Community Edition default for the bundled Keycloak subchart is `camunda/keycloak:26.3.3` in 8.7, 8.8 and 8.9. CVE-2026-18963 is a reported critical password-reset flaw in Keycloak that can lead to account takeover, fixed in Keycloak 26.7.2 — so that default is affected.

The tag cannot simply be bumped, because the chart pins a tag line that has been discontinued. Per [`keycloak-26/bases.yml`](https://github.com/camunda/keycloak/blob/main/keycloak-26/bases.yml) in `camunda/keycloak`:

| Tag line | Base image | State |
| --- | --- | --- |
| unprefixed + `bitnami-*` | `docker.io/bitnamilegacy/keycloak:26.3.3-debian-12-r0` | frozen |
| `quay-*` / `quay-optimized-*` / `latest` | `quay.io/keycloak/keycloak:26.7.2-1` | maintained |
| `bitnami-ee-*` (enterprise registry) | `registry.camunda.cloud/vendor-ee/keycloak:26.7.2-debian-12-r1` | maintained |

`keycloak-26/Dockerfile` says so outright: *"DEPRECATED — Bitnami-based Keycloak image. […] This variant is frozen: its AWS Advanced JDBC Wrapper stays at 2.6.8 […] and is no longer tracked by Renovate."*

So the weekly `26.3.3-debian-12-r0-<date>` tags are rebuilds of a frozen base, not version bumps, and `26.3.3` will not receive this fix or any future one.

Renovate is not misreading anything: `identityKeycloak.image.tag` carries no annotation, so it is tracked by the `helm-values` manager against `docker.io/camunda/keycloak`, where `26.3.3` genuinely is the newest tag on that line.

Enterprise is already covered — `keycloak-ee/keycloak` went to `26.7.2` in #6930.

### What's in this PR?

A render-time warning, so affected users learn that the image line is discontinued instead of silently running an affected Keycloak while waiting for a bump that will never arrive.

The warning is declared in the existing `camunda.constraints.warnings` define (`templates/camunda/constraints.tpl` on 8.7, `templates/common/constraints.tpl` on 8.8/8.9), which reaches both channels already wired for it: `helm install`/`helm upgrade` output via `NOTES.txt`, and the `<release>-warnings` ConfigMap on the GitOps path.

It points at the two supported ways out:

- **Recommended — the Keycloak Operator.** The [migration guide](https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/) recommends operator-based deployments over the Bitnami subcharts and maps this component explicitly: *"Bitnami Keycloak (StatefulSet) → Keycloak Operator CR replaces StatefulSet"*. The guide is linked unversioned because the `/docs/8.7/` and `/docs/8.8/` paths 404 while the unversioned and `/docs/8.9/` ones resolve, and this warning ships in all three.
- **Enterprise — deploy with `values-enterprise.yaml`.** The overlay already pins `keycloak-ee/keycloak:26.7.2`, and that image is a genuine drop-in: `keycloak-ee` is the `bitnami-ee` line, built on `vendor-ee/keycloak:26.7.2-debian-12-r1`, so it keeps the Bitnami contract this subchart depends on. The warning names the overlay rather than the image because setting `identityKeycloak.image` by hand skips the `registry-camunda-cloud` pull secret and `global.security.allowInsecureImages`, which the overlay carries alongside the tag. Rendering any of 8.7/8.8/8.9 with `-f values-enterprise.yaml` silences the warning.

Deliberately **not** suggested: overriding onto `camunda/keycloak:quay-*`. Those follow upstream Keycloak conventions — `/opt/keycloak/…` instead of `/opt/bitnami/keycloak/…`, `KC_BOOTSTRAP_ADMIN_USERNAME` / `KC_DB_*` instead of `KEYCLOAK_ADMIN` plus the Bitnami variables, and an explicit `start` command. `charts/internal-keycloak-26/values.yaml` already documents that split in its `command` parameter. Recommending them as a quick image override would invite a broken deployment.

Two implementation notes:

- **Version-gated, not unconditional.** It fires only when `identityKeycloak.enabled` and the resolved version is `< 26.7.2`, so it stays silent for anyone who already overrode `identityKeycloak.image` — including onto a `quay-*` tag, which does not parse as a bare `X.Y.Z` and so reads as "migrated".
- **`regexFind` before `semverCompare`.** Tags carry a Bitnami revision or rebuild-date suffix (`26.3.3-debian-12-r0-2026-08-27-001`), and `semverCompare` errors on input it cannot parse. Trimming to the leading `X.Y.Z` catches those dated rebuild tags and keeps a non-semver tag from breaking the render.

8.10 needs no change — the bundled subchart was removed in #6146. 8.9 already warns that Bitnami-based subcharts are deprecated; 8.7 and 8.8 carry no such warning, which is where this adds the most.

Tests: a `TestBundledKeycloakCveWarning` case matrix per version (affected version warns, Bitnami revision suffix parsed, 26.7.2 silent, unparseable tag silent and render-safe, disabled subchart silent). 8.7 enables `identityKeycloak` by default, so its existing warning-free render case now disables the subchart explicitly.

Verified: `make helm.lint` clean on all three charts; `make go.test` for 8.7/8.8/8.9 shows no new failures (the `TestGolden*Defaults` failures present locally reproduce identically on `main`).

### Deliberate choices, flagged for review

Two points where the warning knowingly trades precision for safety, raised by `crev` and kept:

- **No `image.digest` guard.** Setting `identityKeycloak.image.digest` overrides the tag, so a tag-based check can misreport in both directions. Skipping the warning whenever a digest is set would remove the false positive (patched digest, stale tag) at the cost of a false negative (vulnerable digest, no warning at all). For a CVE notice the false positive is the safer failure mode, and it is self-clearing — update the tag to match the digest and the warning stops. The chart cannot resolve a digest to a version at render time, so there is no exact option. Happy to add the guard if reviewers prefer the quieter behaviour.
- **`NotContains` without `NoError` in the no-warn cases.** Deliberate: with `identityKeycloak.enabled=false` on 8.7 no warnings ConfigMap renders at all, so `--show-only` errors and a `NoError` assertion would fail. The other no-warn cases only render because of unrelated default deprecations (`documentStore` on 8.8), so asserting `NoError` there would couple these tests to warnings this PR does not own. A genuinely broken template still fails loudly, because every positive case asserts `NoError`.

Out of scope: 8.6 pins `camunda/keycloak:25.0.6` and is likewise affected, but it has no active CI and was not part of this change. Tracked in #6987.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
