### PR TITLE
fix: stop emitting orchestration log4j2.xml twice when extraConfiguration supplies it

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1697,6 +1697,26 @@ Usage:
 {{- end -}}
 
 {{- /*
+NOTE: filename companion to extraConfigHasPath, matching on the entry's "file" rather than
+its parsed content. Unlike the content helpers it does NOT skip springImport:false entries:
+a non-Spring file such as log4j2.xml still occupies a ConfigMap data key and a subPath
+volumeMount, so a chart-rendered file of the same name would collide on both.
+Usage:
+{{ if eq (include "camundaPlatform.extraConfigHasFile" (dict
+  "extraConfiguration" .Values.orchestration.extraConfiguration
+  "file" "log4j2.xml")) "true" }}
+*/ -}}
+{{- define "camundaPlatform.extraConfigHasFile" -}}
+{{- $found := "" -}}
+{{- range .extraConfiguration -}}
+  {{- if eq (.file | default "") $.file -}}
+    {{- $found = "true" -}}
+  {{- end -}}
+{{- end -}}
+{{- $found -}}
+{{- end -}}
+
+{{- /*
 NOTE: dotted-key companion to extraConfigHasPath. Spring accepts the relaxed form
 "camunda.secrets.stores.aws.default.region: x", which fromYaml parses as one top-level
 key, so the nested walk in extraConfigHasPath cannot see it. Spring also accepts every

--- a/charts/camunda-platform-8.10/templates/orchestration/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/configmap.yaml
@@ -35,8 +35,8 @@ data:
   application.yaml: |
     {{- (include (print $.Template.BasePath "/orchestration/files/_application.yaml") $) | indent 4 }}
   {{- end }}
+  {{- if and .Values.orchestration.log4j2 (ne (include "camundaPlatform.extraConfigHasFile" (dict "extraConfiguration" .Values.orchestration.extraConfiguration "file" "log4j2.xml")) "true") }}
   log4j2.xml: |
-  {{- if .Values.orchestration.log4j2 }}
     {{ .Values.orchestration.log4j2 | indent 4 | trim }}
   {{- end }}
 

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -260,7 +260,7 @@ spec:
               mountPath: /exporters
             - mountPath: /tmp
               name: tmp
-            {{- if .Values.orchestration.log4j2 }}
+            {{- if and .Values.orchestration.log4j2 (ne (include "camundaPlatform.extraConfigHasFile" (dict "extraConfiguration" .Values.orchestration.extraConfiguration "file" "log4j2.xml")) "true") }}
             - name: config
               mountPath: /usr/local/camunda/config/log4j2.xml
               subPath: log4j2.xml

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
@@ -444,6 +444,92 @@ func (s *ConfigmapLegacyTemplateTest) TestExtraConfigurationSpringImport() {
 					"Second file content should be present in ConfigMap even with springImport: false")
 			},
 		},
+		{
+			Name:   "TestLog4j2KeyNotEmittedWhenUnset",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Equal(0, strings.Count(output, "log4j2.xml: |"),
+					"log4j2.xml should not be emitted at all when orchestration.log4j2 is unset")
+			},
+		},
+		{
+			Name: "TestLog4j2KeyEmittedOnceFromDeprecatedKey",
+			Values: map[string]string{
+				"orchestration.log4j2": "<Configuration>deprecated</Configuration>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Equal(1, strings.Count(output, "log4j2.xml: |"),
+					"log4j2.xml should be emitted exactly once")
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["log4j2.xml"], "<Configuration>deprecated</Configuration>",
+					"orchestration.log4j2 content should be used when extraConfiguration does not supply the file")
+			},
+		},
+		{
+			Name: "TestLog4j2KeyEmittedOnceFromExtraConfiguration",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":         "log4j2.xml",
+				"orchestration.extraConfiguration[0].springImport": "false",
+				"orchestration.extraConfiguration[0].content":      "<Configuration>operator</Configuration>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Equal(1, strings.Count(output, "log4j2.xml: |"),
+					"log4j2.xml must not be defined twice in ConfigMap data")
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["log4j2.xml"], "<Configuration>operator</Configuration>",
+					"extraConfiguration content should be used")
+			},
+		},
+		{
+			Name: "TestLog4j2ExtraConfigurationWinsOverDeprecatedKey",
+			Values: map[string]string{
+				"orchestration.log4j2":                             "<Configuration>deprecated</Configuration>",
+				"orchestration.extraConfiguration[0].file":         "log4j2.xml",
+				"orchestration.extraConfiguration[0].springImport": "false",
+				"orchestration.extraConfiguration[0].content":      "<Configuration>operator</Configuration>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Equal(1, strings.Count(output, "log4j2.xml: |"),
+					"log4j2.xml must not be defined twice when both sources set it")
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["log4j2.xml"], "<Configuration>operator</Configuration>",
+					"extraConfiguration should win over the deprecated orchestration.log4j2")
+				s.Require().NotContains(configmap.Data["log4j2.xml"], "deprecated",
+					"deprecated orchestration.log4j2 content should be suppressed")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapLegacyTemplateTest) TestExtraConfigurationDoesNotSuppressChartRenderedProperties() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestChartStillRendersItsOwnValueAlongsideExtraConfiguration",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":    "operator-override.yaml",
+				"orchestration.extraConfiguration[0].content": "camunda:\n  data:\n    snapshot-period: 7m\n",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				s.Require().Contains(applicationYaml, "optional:file:/usr/local/camunda/config/operator-override.yaml",
+					"the operator file must be imported by the chart's application.yaml")
+				s.Require().Contains(applicationYaml, "snapshot-period: \"5m\"",
+					"the chart must keep rendering its own default; the import outranks it at runtime")
+				s.Require().Contains(configmap.Data["operator-override.yaml"], "snapshot-period: 7m",
+					"the operator value must be delivered as its own imported document")
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -197,4 +197,3 @@ data:
         cluster:
           clusterName: camunda-platform-test-zeebe
     
-  log4j2.xml: |

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-rdbms.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-rdbms.golden.yaml
@@ -188,4 +188,3 @@ data:
         cluster:
           clusterName: camunda-platform-test-zeebe
     
-  log4j2.xml: |

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -207,4 +207,3 @@ data:
         cluster:
           clusterName: camunda-platform-test-zeebe
     
-  log4j2.xml: |

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
@@ -197,4 +197,3 @@ data:
         cluster:
           clusterName: camunda-platform-test-zeebe
     
-  log4j2.xml: |

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -352,6 +352,46 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 				s.Require().Equal("log4j2.xml", volumeMounts[4].SubPath)
 			},
 		}, {
+			Name: "TestLog4j2MountNotDuplicatedWhenBothSourcesSetIt",
+			Values: map[string]string{
+				"orchestration.log4j2":                             "<Configuration>deprecated</Configuration>",
+				"orchestration.extraConfiguration[0].file":         "log4j2.xml",
+				"orchestration.extraConfiguration[0].springImport": "false",
+				"orchestration.extraConfiguration[0].content":      "<Configuration>operator</Configuration>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var statefulSet appsv1.StatefulSet
+				helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+
+				count := 0
+				for _, vm := range statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts {
+					if vm.MountPath == "/usr/local/camunda/config/log4j2.xml" {
+						count++
+					}
+				}
+				s.Require().Equal(1, count,
+					"log4j2.xml must be mounted exactly once when orchestration.log4j2 and extraConfiguration both set it")
+			},
+		}, {
+			Name: "TestLog4j2MountedOnceFromExtraConfigurationAlone",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":         "log4j2.xml",
+				"orchestration.extraConfiguration[0].springImport": "false",
+				"orchestration.extraConfiguration[0].content":      "<Configuration>operator</Configuration>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var statefulSet appsv1.StatefulSet
+				helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+
+				count := 0
+				for _, vm := range statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts {
+					if vm.MountPath == "/usr/local/camunda/config/log4j2.xml" {
+						count++
+					}
+				}
+				s.Require().Equal(1, count, "log4j2.xml should be mounted once from extraConfiguration")
+			},
+		}, {
 			Name:                 "TestContainerSetExtraVolumes",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6997.

### What's in this PR?

`templates/orchestration/configmap.yaml` emitted the `log4j2.xml` key unconditionally and gated only
its body, so an `orchestration.extraConfiguration` entry named `log4j2.xml` produced the key twice.
With the deprecated `orchestration.log4j2` also set, `statefulset.yaml` emitted a second
`volumeMount` on `/usr/local/camunda/config/log4j2.xml`, which Kubernetes rejects
(`ValidateVolumeMounts`: `mountPath ... must be unique`), so the install failed.

`extraConfiguration` now wins, matching ADR-0091:

| `orchestration.log4j2` | extraConfig `log4j2.xml` | before | after |
|---|---|---|---|
| unset | unset | empty key emitted, no mount | key not emitted |
| set | unset | key + mount | unchanged |
| unset | set | key defined twice | operator's key + mount only |
| set | set | key twice **and** duplicate mountPath → install rejected | operator's key + mount only |

- `templates/common/_helpers.tpl` — new `camundaPlatform.extraConfigHasFile`, a filename-match
  companion to the existing `extraConfigHasPath` family, which all walk parsed content and cannot
  match on `file`. It deliberately does not skip `springImport: false` entries: a non-Spring file
  still occupies a ConfigMap key and a `subPath` mount.
- `templates/orchestration/configmap.yaml` and `statefulset.yaml` — gate the chart's own
  `log4j2.xml` key and mount on that helper.
- `constraints.tpl` untouched, so an operator in the both-set case still gets the
  `orchestration.log4j2` DEPRECATION warning while they clean up.

Golden churn is four orchestration configmaps losing the empty `log4j2.xml` key;
`configmap-log4j2.golden.yaml` keeps it, populated.

Tests cover all four combinations plus mount counts, using the literal filename `log4j2.xml` — every
pre-existing fixture used `log4j2-spring.xml`, so nothing exercised the colliding name. Verified they
fail against the unfixed templates.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
