### PR TITLE
ci: fix release pipeline tool resolution and post-release PR labelling

### DIFF
--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -289,15 +289,15 @@ jobs:
           chart_path="charts/camunda-platform-${{ steps.package.outputs.chart_dir_id }}"
           head_ref="${{ steps.release-please.outputs.head_ref }}"
 
+          make helm.repos-add
+          make helm.dependency-update chartPath="${chart_path}"
+
           # In dry-run no release-please branch exists; generate against the
           # dev-SHA checkout instead to keep real coverage of the generators.
           if [[ "${DRY_RUN}" != "true" ]]; then
             git fetch origin "${head_ref}"
             git checkout "${head_ref}"
           fi
-
-          make helm.repos-add
-          make helm.dependency-update chartPath="${chart_path}"
 
           # Chart.yaml release annotations + RELEASE-NOTES.md (body + image footer).
           /tmp/release-tools release-notes --main "${chart_path}"

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -435,6 +435,9 @@ jobs:
             helm-ct
             yq
 
+      - name: Build release-tools
+        run: cd scripts/release-tools && go build -o /tmp/release-tools .
+
       - name: Label PRs with version
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
@@ -453,8 +456,6 @@ jobs:
           head_ref="release-please--branches--main--components--camunda-platform-${APP_VERSION}"
           git fetch origin "${head_ref}" --tags
           git checkout "${head_ref}"
-
-          (cd scripts/release-tools && go build -o /tmp/release-tools .)
 
           /tmp/release-tools stamp-release --app "${APP_VERSION}" --chart-version "${CHART_VERSION}"
           /tmp/release-tools version-matrix --readme "${APP_VERSION}"

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -442,7 +442,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
         run: |
-          make release.set-prs-version-label chartPath="charts/camunda-platform-${{ needs.release.outputs.chart-dir-id }}"
+          make release.set-prs-version-label \
+            chartPath="charts/camunda-platform-${{ needs.release.outputs.chart-dir-id }}" \
+            chartVersion="${{ needs.release.outputs.version }}"
 
       - name: Stamp release date on the release-please PR
         id: stamp

--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -99,11 +99,8 @@ echo "${chart_dirs}" | while read -r chart_dir; do
     echo "Apps version: ${app_version}"
     echo "Chart version: ${chart_version}"
 
-    # Create the chart version label if it doesn't exist.
-    # We need to use grep because GH CLI doesn't support exact match.
-    gh label list --search "${chart_version_label}" | grep "${chart_version_label}" ||
-        gh label create "${chart_version_label}" --color "0052CC" \
-            --description "Issues and PRs related to chart version ${chart_version}"
+    gh label create "${chart_version_label}" --color "0052CC" \
+        --description "Issues and PRs related to chart version ${chart_version}" --force
 
     # Update GH PRs and Issues with the chart version.
     # Labeling is best-effort: a single failure (non-PR reference, transient API

--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -89,7 +89,7 @@ fi
 echo "${chart_dirs}" | while read -r chart_dir; do
     [[ -z "${chart_dir}" ]] && continue
     app_version="$(yq '.appVersion | sub("\..$", "")' ${chart_dir}/Chart.yaml)"
-    chart_version="$(yq '.version' ${chart_dir}/Chart.yaml)"
+    chart_version="${chartVersion:-$(yq '.version' ${chart_dir}/Chart.yaml)}"
     app_version_label="version/${app_version}"
     # The "version:x.y.z" label format is used by the support team,
     # it must not changed without checking with the support team.


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #7015.

### What's in this PR?

Three defects hit while releasing 14.9.0 in run 33598177162, one commit each.

**Tool resolution.** `install-tool-versions` reads `.tool-versions` from the working directory, so
a step that installs from `main`'s pins and then checks out a release-please branch resolves its
shims against *that branch's* pins. `main` pinned `golang 1.27.1`, the branch `golang 1.27.0`, and
`go build` exited 126.

- `chart-release-public.yaml`: build `release-tools` into `/tmp` before the checkout, as the
  `release` job already does.
- `chart-promote-rc.yaml`: move `make helm.repos-add` / `helm.dependency-update` before the
  checkout. Dry-run already runs both without it, and `Chart.lock` / `*.tgz` are gitignored so the
  resolved dependencies survive it.

**Label idempotence.** The `gh label list --search` guard is index-backed and lagged behind a label
the job's own earlier attempt had created, so `gh label create` failed the job under
`set -euo pipefail`. Replaced with `gh label create --force`.

**Label version.** `chart_version` came from the `main` worktree, which still holds the previous
release's version — 14.9.0's PRs got `version:8.9-14.8.5`. The workflow now passes `chartVersion=`
from `needs.release.outputs.version`, matching the existing `chartPath=` override; the worktree
read stays as the local fallback.

Verified: `make` variable passthrough with and without `chartVersion`; `bash -n`; `shellcheck` and
`actionlint` finding sets unchanged from `main`; `release-tools` builds on the pinned `go1.27.1`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
