### PR TITLE
ci: add the missing 8.10 kcor scenario and run the full e2e suite for hub

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -406,6 +406,43 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+        - name: keycloak-original
+          enabled: false
+          shortname: kcor
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - hub-ping
+            - hub-ping-keycloak-token-endpoint
+          e2e-full-suite: true
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+              values-file: test/integration/companion-values/keycloak.yaml
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+            - chart: charts/internal-postgresql
+              release-name: postgresql
+              values-file: test/integration/companion-values/postgresql.yaml
+              env-vars:
+                - RDBMS_POSTGRESQL_USERNAME
+                - RDBMS_POSTGRESQL_PASSWORD
+          post-deploy:
+            script: post-deploy-hub-ping.sh
+            description: |
+              Waits for the authenticated Orchestration Cluster ping to register its
+              uniquely named cluster in Hub's database.
         - name: gateway-keycloak
           enabled: true
           shortname: gatkc

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -58,6 +58,9 @@ integration:
       shortname: keorg
       tier: 2
       enabled: true
+    - id: keycloak-original-install
+      shortname: kcor
+      enabled: false
     - id: gateway-keycloak
       shortname: gatkc
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/keycloak-original-install.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/keycloak-original-install.yaml
@@ -1,0 +1,19 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - hub-ping
+  - hub-ping-keycloak-token-endpoint
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+post-deploy: hub-ping
+e2e-full-suite: true
+dependencies:
+  - keycloak
+  - elasticsearch
+  - postgresql


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to #6841 (*ci: run full Playwright e2e suite for the alwaysgreen scenario*), which built the
per-leg e2e matrix and turned it on for `alwaysgreen` only. Related:
[team-test-automation#78](https://github.com/camunda/team-test-automation/issues/78) — AlwaysGreen
Iteration 2, expanding PR-level SM/Helm coverage from smoke to the full Playwright suite.

This applies #6841's documented opt-in to the **camunda-hub** cell, and fixes a resolution bug found
while doing so.

`camunda-hub` calls `test-integration-template.yaml@main` with `scenario: keycloak-original` and
`shortname: kcor`
([stage-helm-tests.yml](https://github.com/camunda/camunda-hub/blob/main/.github/workflows/stage-helm-tests.yml)).
`kcor` exists in the 8.8 and 8.9 registries but **never existed in 8.10**, so both resolvers fall
back:

- `ResolveE2ELegs` falls back to name lookup and returns the **first** scenario named
  `keycloak-original` — `keycloak-original-upgrade` (manifest line 54), an `upgrade-minor` scenario
  supplying the e2e config for an `install` cell. This is exactly the cross-file resolution hazard
  #6841 called out ("*8.7 has two with `name: keycloak-original`. A scenario could resolve to another
  file's declarations. Resolution now prefers `shortname`*") — the shortname-first guard cannot help
  when the shortname is absent.
- `matrix.Filter`'s deliberate fallback drops the shortname filter when scenario+shortname match
  nothing, so the **install matches two scenarios and deploys twice** into the same namespace.

Observed in camunda-hub run
[33535545134](https://github.com/camunda/camunda-hub/actions/runs/33535545134):

```
Deploying matrix entry ... shortname=keorg  features=[]
Deploying matrix entry ... shortname=keyco  features=["hub-ping","hub-ping-keycloak-token-endpoint"]
  [PASS] 8.10/keycloak-original (keorg, flow=install)   2m57s
  [PASS] 8.10/keycloak-original (keyco, flow=install)   1m40s
```

Two sequential installs, 4m37s, with the final cluster state being whichever landed second.

The coverage gap this closes: hub's cell deploys the PR's own Web Modeler build
(`webModeler.restapi.image` → `team-hub/hub-restapi-self-managed:ci-<sha>`, and since 8.10 bundles the
frontend into the single `camunda/hub` image that is the PR's frontend), but only ever ran
`smoke-tests.spec.ts`. So camunda-hub#28259 ("*rename play package to test-studio*") renamed
`data-test="play-configuration-overlay"` → `test-studio-configuration-overlay` and merged green, then
broke `play.spec.ts` across the SM and SaaS nightlies the following night
(camunda/c8-cross-component-e2e-tests#3268, #3280, #3281, #3287). `play.spec.ts` is in the
`full-suite` project, so the full leg would have caught it on the PR.

### What's in this PR?

Declares the missing 8.10 scenario, with the full-suite leg enabled:

- `charts/camunda-platform-8.10/test/ci/registry/scenarios/keycloak-original-install.yaml` (new) —
  mirrors `keycloak-original-install-tier1` (`features: [hub-ping, hub-ping-keycloak-token-endpoint]`,
  `post-deploy: hub-ping`) plus `e2e-full-suite: true`. Tier1 is mirrored, not tier2, because tier1's
  config is what wins today as the second install — so the deployed state and its `hub-ping`
  post-deploy check are unchanged.
- `manifest.yaml` — `id: keycloak-original-install`, `shortname: kcor`, `enabled: false`. As with
  `alwaysgreen`, `enabled: false` only keeps it out of *this* repo's generated PR matrix; the resolver
  ignores `enabled`.
- `registry-snapshot.yaml` — regenerated via `make go.update-registry-golden`.

Nothing changes in camunda-hub: it already sends `shortname: kcor`, which simply had nothing to bind
to. Per #6841, the legs are declared here and take effect on the next gate run, because hub pins
`camunda-helm-git-ref: main`.

**Blocking**: the full leg is left at its default, **non-blocking** (`continue-on-error: !blocking`),
matching `alwaysgreen` and the connectors caller. `e2e-full-suite-blocking: true` can promote it later.
Two reasons not to promote it now: #6841 already recorded full-suite flakiness on `web-modeler-user-flows`,
`hto-user-flows`, `play`, `test-setup` and `connectors-user-flows`; and the 8.9 full leg was red in the
merge queue today
([33601304648](https://github.com/camunda/camunda-platform-helm/actions/runs/33601304648) — 2 failures
in `web-modeler-user-flows`, Form.js Integration with User Task / Start form `@tasklistV2`).

Note for the calling repo, same caveat connectors documents: camunda-hub's `check-results` job reads
`needs.*.result`, which cannot see a `continue-on-error` leg inside a called workflow. The full leg
will run and report in the UI but will not redden hub's Helm check until hub reads the jobs API (as
`camunda/connectors` does) or the leg is promoted to blocking.

**Scope**: 8.10 only, which is what hub's `main`-targeting PRs resolve to. 8.8 and 8.9 already have a
`kcor` scenario that resolves exactly, so they are untouched and stay smoke-only; adding
`e2e-full-suite: true` there later is a one-line edit per version.

#### Verification

Against `origin/main`, via `deploy-camunda ci e2e-matrix` and `deploy-camunda matrix list` with hub's
exact filters:

| | before | after |
|---|---|---|
| hub e2e legs (`--shortname kcor`) | `[{smoke, blocking}]` | `[{smoke, blocking}, {full, non-blocking}]` |
| hub install match | 2 entries (`keorg` + `keyco`) | 1 entry (`kcor`) |
| this repo's tier-1 PR matrix (8.10) | 8 entries | 8 entries |
| this repo's tier-2 matrix (8.10) | 26 entries | 26 entries |

`go test ./...` in `scripts/deploy-camunda` — 9 packages, all pass, including the registry validator
and the `TestRegistryGolden` snapshot check.

The misresolution was confirmed by flagging each `keycloak-original` candidate in turn and re-running
the resolver: only flagging `keycloak-original-upgrade` changed hub's legs, and neither
`keycloak-original-install-tier1` nor `-tier2` did.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
