### PR TITLE
test: [GCPSECRETCI 2/2] add GCP Secret Manager secret-store CI scenario for 8.10

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -701,6 +701,39 @@ integration:
             description: |
               Resolves a value from the mounted file secret store through the v2 gateway
               API and verifies that the runtime returns the expected value.
+        - name: secretstore-gcp
+          enabled: true
+          shortname: secgc
+          auth: basic
+          flow: install
+          platforms:
+            - gke
+          exclude:
+            - orchestration-grpc
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: basic
+          persistence: elasticsearch
+          features:
+            - secretstore-gcp
+          skip-e2e: true
+          dependencies:
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+          post-deploy:
+            script: post-deploy-secretstore-gcp.sh
+            description: |
+              Grants roles/secretmanager.secretAccessor on the camunda-ci-secretstore-token
+              fixture to this run's GKE workload principal, resolves the secret through the v2
+              gateway API, and revokes the binding on exit. Also asserts the Orchestration
+              ServiceAccount carries no iam.gke.io/gcp-service-account annotation and the
+              container sets no GOOGLE_APPLICATION_CREDENTIALS, so the value can only have
+              resolved through workload identity. Requires an authenticated gcloud.
         - name: rdbms-self-signed
           enabled: true
           shortname: rdbss

--- a/charts/camunda-platform-8.10/test/ci/registry/hooks/secretstore-gcp-verify.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/hooks/secretstore-gcp-verify.yaml
@@ -1,0 +1,8 @@
+script: post-deploy-secretstore-gcp.sh
+description: |
+  Grants roles/secretmanager.secretAccessor on the camunda-ci-secretstore-token
+  fixture to this run's GKE workload principal, resolves the secret through the v2
+  gateway API, and revokes the binding on exit. Also asserts the Orchestration
+  ServiceAccount carries no iam.gke.io/gcp-service-account annotation and the
+  container sets no GOOGLE_APPLICATION_CREDENTIALS, so the value can only have
+  resolved through workload identity. Requires an authenticated gcloud.

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -90,6 +90,10 @@ integration:
       shortname: secfl
       tier: 2
       enabled: true
+    - id: secretstore-gcp
+      shortname: secgc
+      tier: 2
+      enabled: true
     - id: rdbms-self-signed
       shortname: rdbss
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/secretstore-gcp.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/secretstore-gcp.yaml
@@ -1,0 +1,18 @@
+name: secretstore-gcp
+auth: basic
+flows:
+  - install
+identity: basic
+persistence: elasticsearch
+skip-e2e: true
+features:
+  - secretstore-gcp
+exclude:
+  - orchestration-grpc
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+post-deploy: secretstore-gcp-verify
+dependencies:
+  - elasticsearch

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/secretstore-gcp.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/secretstore-gcp.yaml
@@ -1,0 +1,28 @@
+# GCP Secret Manager secret store configuration for centralized secret resolution.
+# Deploys only the Orchestration Cluster; the hook verifies secret resolution.
+#
+# projectId addresses the fixture owned by camunda/team-distribution at
+# infrastructure/gcp/camunda-distribution/gke-distro-ci/secret-store/.
+# gcpServiceAccount is deliberately unset: the fixture has no linked IAM service
+# account, and the hook grants access to the per-run GKE workload principal instead.
+
+identity:
+  enabled: false
+
+webModeler:
+  enabled: false
+
+camundaHub:
+  enabled: false
+
+console:
+  enabled: false
+
+optimize:
+  enabled: false
+
+orchestration:
+  secretStore:
+    gcp:
+      default:
+        projectId: camunda-distribution

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-secretstore-gcp.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-secretstore-gcp.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Copyright 2026 Camunda Services GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+NAMESPACE="${TEST_NAMESPACE:?TEST_NAMESPACE must be set}"
+RELEASE="${RELEASE_NAME:-integration}"
+RESOLVE_USER="${SECRET_STORE_RESOLVE_USER:-demo}"
+RESOLVE_PASSWORD="${SECRET_STORE_RESOLVE_PASSWORD:-demo}"
+
+# Owned by camunda/team-distribution:
+# infrastructure/gcp/camunda-distribution/gke-distro-ci/secret-store/README.md
+GCP_PROJECT="camunda-distribution"
+GCP_PROJECT_NUMBER="922145893973"
+SECRET_ID="camunda-ci-secretstore-token"
+EXPECTED_VALUE="secret-store-gcp-integration-value"
+WORKLOAD_POOL="${GCP_PROJECT}.svc.id.goog"
+
+SERVICE_ACCOUNT="${RELEASE}-zeebe"
+PRINCIPAL="principal://iam.googleapis.com/projects/${GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WORKLOAD_POOL}/subject/ns/${NAMESPACE}/sa/${SERVICE_ACCOUNT}"
+
+CONTEXT_ARGS=()
+if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  CONTEXT_ARGS=(--context "${KUBE_CONTEXT}")
+fi
+
+for tool in gcloud jq curl; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "${tool} is required but not on PATH." >&2
+    exit 1
+  }
+done
+
+# The fixture carries no standing accessor binding, so the grant below is the only
+# thing that lets this run read it. Revoked on exit so a failed run leaks nothing.
+# shellcheck disable=SC2329 # invoked indirectly via trap
+revoke_binding() {
+  gcloud secrets remove-iam-policy-binding "${SECRET_ID}" \
+    --project "${GCP_PROJECT}" \
+    --role roles/secretmanager.secretAccessor \
+    --member "${PRINCIPAL}" \
+    --quiet >/dev/null 2>&1 || \
+    echo "WARNING: could not revoke ${PRINCIPAL} from ${SECRET_ID}; check the fixture IAM policy." >&2
+}
+
+echo "Granting roles/secretmanager.secretAccessor on ${SECRET_ID} to the per-run principal."
+gcloud secrets add-iam-policy-binding "${SECRET_ID}" \
+  --project "${GCP_PROJECT}" \
+  --role roles/secretmanager.secretAccessor \
+  --member "${PRINCIPAL}" \
+  --quiet >/dev/null
+trap revoke_binding EXIT
+
+# The chart must reach GCP as the workload principal granted above. A ServiceAccount
+# annotation or a mounted key would mean the value resolved through some other identity
+# and the wiring under test was never exercised.
+if kubectl "${CONTEXT_ARGS[@]}" -n "${NAMESPACE}" get serviceaccount "${SERVICE_ACCOUNT}" \
+    -o jsonpath='{.metadata.annotations}' 2>/dev/null | grep -q 'iam.gke.io/gcp-service-account'; then
+  echo "ServiceAccount ${SERVICE_ACCOUNT} carries iam.gke.io/gcp-service-account; this scenario must not set gcpServiceAccount." >&2
+  exit 1
+fi
+
+if kubectl "${CONTEXT_ARGS[@]}" -n "${NAMESPACE}" get statefulset "${RELEASE}-zeebe" \
+    -o jsonpath='{.spec.template.spec.containers[*].env[*].name}' 2>/dev/null \
+    | tr ' ' '\n' | grep -qx 'GOOGLE_APPLICATION_CREDENTIALS'; then
+  echo "GOOGLE_APPLICATION_CREDENTIALS is set on the Orchestration container; static credentials would take precedence over workload identity." >&2
+  exit 1
+fi
+
+PORT_FORWARD_LOG="$(mktemp)"
+kubectl "${CONTEXT_ARGS[@]}" -n "${NAMESPACE}" port-forward \
+  "service/${RELEASE}-zeebe-gateway" ":8080" >"${PORT_FORWARD_LOG}" 2>&1 &
+PORT_FORWARD_PID=$!
+trap 'kill "${PORT_FORWARD_PID}" 2>/dev/null || true; rm -f "${PORT_FORWARD_LOG}"; revoke_binding' EXIT
+
+# kubectl picks the local port when it is left empty; read it back from its first line.
+LOCAL_PORT=""
+for _ in {1..30}; do
+  LOCAL_PORT="$(sed -nE 's/^Forwarding from 127\.0\.0\.1:([0-9]+).*/\1/p' "${PORT_FORWARD_LOG}" | head -1)"
+  [[ -n "${LOCAL_PORT}" ]] && break
+  sleep 1
+done
+if [[ -z "${LOCAL_PORT}" ]]; then
+  echo "Port-forward to ${RELEASE}-zeebe-gateway never reported a local port." >&2
+  cat "${PORT_FORWARD_LOG}" >&2
+  exit 1
+fi
+
+# The retry budget also absorbs IAM propagation on the binding granted above.
+for attempt in {1..60}; do
+  # kubectl port-forward exits with its target pod; without this the remaining attempts
+  # curl a dead local port and the diagnostics blame the secret store.
+  kill -0 "${PORT_FORWARD_PID}" 2>/dev/null || {
+    echo "Port-forward to ${RELEASE}-zeebe-gateway died before the secret resolved." >&2
+    break
+  }
+
+  # --max-time bounds a gateway that accepts the connection and never answers; without it
+  # the retry budget does not hold because curl never returns.
+  response="$(curl --silent --show-error --max-time 10 \
+    --user "${RESOLVE_USER}:${RESOLVE_PASSWORD}" \
+    --header 'Content-Type: application/json' \
+    --data "{\"references\":[\"camunda.secrets.${SECRET_ID}\"]}" \
+    "http://127.0.0.1:${LOCAL_PORT}/orchestration/v2/secrets/resolve" 2>/dev/null)" || true
+
+  if jq -e --arg want "${EXPECTED_VALUE}" --arg ref "camunda.secrets.${SECRET_ID}" \
+      '.resolved == [{"reference":$ref,"value":$want}] and .errors == []' \
+      <<<"${response}" >/dev/null 2>&1; then
+    echo "Secret store resolved ${SECRET_ID} from GCP Secret Manager as the workload principal."
+    exit 0
+  fi
+
+  echo "Waiting for secret-store resolution (attempt ${attempt}/60)..."
+  if (( attempt < 60 )); then
+    sleep 5
+  fi
+done
+
+echo "Secret store did not resolve ${SECRET_ID} to the expected value." >&2
+echo "Last response: ${response:-<none>}" >&2
+kubectl "${CONTEXT_ARGS[@]}" logs -n "${NAMESPACE}" "statefulset/${RELEASE}-zeebe" --all-containers --since=10m >&2 || true
+exit 1


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | camunda/team-distribution#861 | Contract | Publish the fixture's values where the fixture lives. |
> | **2** | **camunda/camunda-platform-helm#7019** | **Scenario** | **Consume them in a GKE integration scenario. ← you are here** |

1 and 2 are independent: the Helm scenario lands `enabled: false` and does not need the contract doc merged first. Ordered contract-first so the documented values stay authoritative.

### Which problem does the PR fix?

Refs #6789. `orchestration.secretStore` supports `file`, `aws` and `gcp`, and all three are covered by unit tests, but CI only ever exercised the file provider against a real cluster. A regression in the rendered `camunda.secrets.stores.gcp` config or in the workload-identity path would ship undetected.

This adds the integration scenario from that issue's remaining acceptance criteria: resolving a real GCP Secret Manager value through `/orchestration/v2/secrets/resolve`, and verifying the intended principal and the absence of JSON service-account credentials.

### What's in this PR?

A `secretstore-gcp` scenario (shortname `secgc`, tier 2) that deploys an Orchestration-only cluster on GKE/distroci against the `camunda-ci-secretstore-token` fixture owned by [camunda/team-distribution](https://github.com/camunda/team-distribution/tree/main/infrastructure/gcp/camunda-distribution/gke-distro-ci/secret-store). No chart templates or `values.yaml` changes — GCP support is already implemented, this is CI wiring only.

**`gcpServiceAccount` is deliberately unset.** The fixture has no linked IAM service account and carries no standing accessor binding, so the hook grants `roles/secretmanager.secretAccessor` to this run's GKE workload principal and revokes it on exit. Setting `gcpServiceAccount` would request a linked-service-account model that does not exist here.

**Grant, verify and revoke all live in the one post-deploy script.** The registry has only `pre-install`, `post-infra`, `post-deploy` and `pre-upgrade` hook kinds — there is no teardown hook — so anything granted in `pre-install` could not be reliably revoked.

**Cleanup is layered, because an in-process trap alone cannot cover every exit.** The `EXIT` trap is installed before the grant; `INT` and `TERM` exit so that trap runs, which matters because `integration-tests-gate.yaml` sets `cancel-in-progress: true` and cancellation is therefore a routine path; and the binding carries a two-hour `request.time` IAM condition so a `SIGKILL` — which `exec.CommandContext` uses when the runner's context is cancelled, and which no trap can intercept — leaves a binding that expires by itself rather than one that persists on the shared fixture. The condition string is byte-identical on add and remove, otherwise gcloud matches no binding on revoke. The exit handler judges cleanup by its post-condition — it re-reads the IAM policy, fails when the principal is still bound, and fails closed when the policy cannot be read — rather than by the remove exit code, which also fails when the grant never landed.

**The resolve request runs with xtrace suppressed.** The lifecycle runner invokes hooks as `bash -x` and `executil.RunCommand` gives the child the full process environment, so an overridden `SECRET_STORE_RESOLVE_PASSWORD` would be traced into the job log by both the variable assignment and the `curl` argument. xtrace is dropped across the whole exchange and the caller's state restored afterwards, because `bash -x` traced the response assignment and the jq comparison argument as well as the `curl` line. Nothing in the repo sets that variable today, so this closes a latent exposure rather than a live one.

**Failure diagnostics are redacted and the guards fail closed.** The retry loop's failure message prints only reference names and errors, never the raw `/resolve` payload, which carries resolved values for any reference the gateway did return. The two workload-identity guards capture their `kubectl get` result instead of piping it into `grep -q` with stderr discarded, so a transient API or RBAC failure exits 1 rather than reading as an absent annotation and satisfying the check it exists to enforce.

The script additionally asserts the Orchestration ServiceAccount carries no `iam.gke.io/gcp-service-account` annotation and the container sets no `GOOGLE_APPLICATION_CREDENTIALS`. Without those, a green result would not prove the value resolved through workload identity rather than an ambient credential.

**Enabled at tier 2**, so it runs on the merge queue and the full matrix, not on PRs.

**The scenario has been executed for real and passes.** Because tier 2 never runs on a PR, it was temporarily set to `tier: 1` on this branch to force a live run, then reverted; that commit pair has been collapsed out, so the branch is a single commit at `tier: 2`. Run [33838440413](https://github.com/camunda/camunda-platform-helm/actions/runs/33838440413), job `install for install on gke - secgc`:

```
Running scenario-specific post-deploy script (declarative)
Granting roles/secretmanager.secretAccessor on camunda-ci-secretstore-token to the per-run principal.
Secret store resolved camunda-ci-secretstore-token from GCP Secret Manager as the workload principal.
post-deploy script completed successfully
```

That settles the three things that could not be verified statically:

- **Resolution is lazy enough for a post-deploy grant.** The resolve succeeded ~6s after the grant with zero retry-loop iterations, so the runtime does not contact GCP at startup and the grant does not need to move to `pre-install`.
- **The runtime accepts dashes in `camunda.secrets.camunda-ci-secretstore-token`,** so the full secret id works and `pathPrefix` is not required.
- **The CI service account can call `setIamPolicy` under the condition-bound `secretStoreFixtureManager` role** — previously unverifiable without mutating IAM.

The two guard assertions (no `iam.gke.io/gcp-service-account` annotation, no `GOOGLE_APPLICATION_CREDENTIALS`) passed, and `gcloud secrets get-iam-policy camunda-ci-secretstore-token` is back to no bindings afterwards, confirming the `trap` revoke fires and the fixture returns to its documented empty steady state.

**The IAM calls have changed since that run.** Grant and revoke now pass `--condition`, so the exact gcloud invocations in run 33838440413 are no longer the ones on this branch. Cleanup was re-verified locally against stubbed `gcloud`/`kubectl`/`curl`: `SIGTERM` exits 143 and `SIGINT` exits 130 with exactly one revoke each, `SIGKILL` performs no revoke (which is precisely what the expiry condition covers), the add and remove condition strings are identical, and no credential reaches the `bash -x` trace while `curl` still receives it. A live re-run is still required before merge, to confirm the CI service account can set a *conditional* binding under its condition-bound `secretStoreFixtureManager` role.

The same stubbed harness covers the review round: a residual binding exits 1, an unreadable IAM policy exits 1, a failed ServiceAccount read exits 1, and a non-matching payload carrying a foreign secret value appears nowhere in stdout, stderr or the trace while its reference names and errors still do.

**Validation.** `matrix` package green uncached across 8.7–8.10; registry snapshot regenerated via `make go.update-registry-golden` and the diff is purely additive; `helm.lint` passes; `shellcheck` and `bash -n` clean; `yamllint` clean under `.github/config/yamllint.yaml`; nothing outside `test/` touched. Rendering the feature layer shows `camunda.secrets.stores.gcp.default.project-id: camunda-distribution`, zero SA annotations and zero `GOOGLE_APPLICATION_CREDENTIALS` — matching what the script enforces — and the Orchestration ServiceAccount is `integration-zeebe`, confirming the `<release>-zeebe` principal derivation.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?