### PR TITLE
feat(8.8,8.9,8.10): document and validate ReadWriteOncePod for broker PVCs

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -265,8 +265,13 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
 {{/*
 Fail with a message if orchestration.pvcAccessModes includes ReadWriteOncePod together with any
 other access mode. Kubernetes requires ReadWriteOncePod to be the sole access mode on a PVC.
+Only checked when a PVC is actually rendered, which mirrors the volumeClaimTemplates gate in
+templates/orchestration/statefulset.yaml.
 */}}
-{{- if and (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) (gt (len .Values.orchestration.pvcAccessModes) 1) }}
+{{- if and (eq (include "camundaPlatform.orchestrationEnabled" .) "true")
+           (eq .Values.orchestration.persistenceType "disk")
+           (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes)
+           (gt (len .Values.orchestration.pvcAccessModes) 1) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
       "orchestration.pvcAccessModes includes \"ReadWriteOncePod\" together with another access mode."
       "Kubernetes requires ReadWriteOncePod to be the only access mode in the list; set orchestration.pvcAccessModes to [\"ReadWriteOncePod\"] on its own."
@@ -828,10 +833,12 @@ The following values inside your values.yaml need to be set but were not:
     "condition" (ne (.Values.global.documentStore.type.inmemory.storeId | toString) "INMEMORY")
     "oldName" "global.documentStore.type.inmemory.storeId" "migration" $componentExtra) }}
 
-  {{- if has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes }}
+  {{- if and (eq (include "camundaPlatform.orchestrationEnabled" .) "true")
+             (eq .Values.orchestration.persistenceType "disk")
+             (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) }}
     {{- $warningMessage := printf "%s %s %s"
         "[camunda][warning]"
-        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; otherwise the PersistentVolumeClaim will remain stuck in Pending."
+        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; without that support the PersistentVolumeClaim may fail to provision or stay Pending."
         "PersistentVolumeClaim accessModes are immutable, so this only applies to new installs / new PVCs, not to an existing StatefulSet via \"helm upgrade\"."
     -}}
     {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -263,6 +263,18 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
 {{- end }}
 
 {{/*
+Fail with a message if orchestration.pvcAccessModes includes ReadWriteOncePod together with any
+other access mode. Kubernetes requires ReadWriteOncePod to be the sole access mode on a PVC.
+*/}}
+{{- if and (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) (gt (len .Values.orchestration.pvcAccessModes) 1) }}
+  {{- $errorMessage := printf "[camunda][error] %s %s"
+      "orchestration.pvcAccessModes includes \"ReadWriteOncePod\" together with another access mode."
+      "Kubernetes requires ReadWriteOncePod to be the only access mode in the list; set orchestration.pvcAccessModes to [\"ReadWriteOncePod\"] on its own."
+  -}}
+  {{ printf "\n%s" $errorMessage | trimSuffix "\n" | fail }}
+{{- end }}
+
+{{/*
 camunda.constraints.warnings
 Non-fatal deprecation/config warnings. Consumed by NOTES.txt (helm install/upgrade) and by
 configmap-warnings.yaml, which renders the "<release>-warnings" ConfigMap on the GitOps path
@@ -815,6 +827,15 @@ The following values inside your values.yaml need to be set but were not:
   {{ include "camundaPlatform.keyDeprecated" (dict
     "condition" (ne (.Values.global.documentStore.type.inmemory.storeId | toString) "INMEMORY")
     "oldName" "global.documentStore.type.inmemory.storeId" "migration" $componentExtra) }}
+
+  {{- if has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes }}
+    {{- $warningMessage := printf "%s %s %s"
+        "[camunda][warning]"
+        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; otherwise the PersistentVolumeClaim will remain stuck in Pending."
+        "PersistentVolumeClaim accessModes are immutable, so this only applies to new installs / new PVCs, not to an existing StatefulSet via \"helm upgrade\"."
+    -}}
+    {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
@@ -334,3 +334,39 @@ func (s *ConfigMapWarningsTemplateTest) TestGlobalIdentityAuthConsoleDeprecation
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapWarningsTemplateTest) TestPvcAccessModesReadWriteOncePodWarning() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ReadWriteOncePodTriggersWarning",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"orchestration.pvcAccessModes[0]":          "ReadWriteOncePod",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"],
+					"orchestration.pvcAccessModes is set to ReadWriteOncePod")
+			},
+		},
+		{
+			Name: "DefaultReadWriteOnceDoesNotTriggerWarning",
+			Values: map[string]string{
+				// Another warning must stay active so the ConfigMap still renders (it is omitted
+				// entirely when no warnings are present, see TestWarningsConfigMapAbsentWhenNoWarnings).
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"orchestration.history.rolloverInterval":   "2d",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().NotContains(configmap.Data["warnings"], "pvcAccessModes")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
@@ -931,6 +931,30 @@ func (s *ConstraintTemplateTest) TestPvcAccessModesReadWriteOncePodGuard() {
 				s.Require().ErrorContains(err, "Kubernetes requires ReadWriteOncePod to be the only access mode in the list")
 			},
 		},
+		{
+			// pvcAccessModes is inert unless persistenceType renders a PVC, so an otherwise
+			// invalid combination must not block the install.
+			Name: "InvalidCombinationDoesNotFailWhenNoPvcIsRendered",
+			Values: map[string]string{
+				"orchestration.persistenceType":   "memory",
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "InvalidCombinationDoesNotFailWhenOrchestrationDisabled",
+			Values: map[string]string{
+				"orchestration.enabled":           "false",
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
@@ -909,3 +909,29 @@ func (s *ConstraintTemplateTest) TestManagementIdentityExternalServiceUrl() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConstraintTemplateTest) TestPvcAccessModesReadWriteOncePodGuard() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ReadWriteOncePodAloneRenders",
+			Values: map[string]string{
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "ReadWriteOncePodWithAnotherAccessModeFails",
+			Values: map[string]string{
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Kubernetes requires ReadWriteOncePod to be the only access mode in the list")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -2288,6 +2288,10 @@ orchestration:
   ## @param orchestration.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
   pvcSize: "32Gi"
   ## @param orchestration.pvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+  # For a storage-layer single-writer guarantee (instead of relying on pod anti-affinity alone), set
+  # this to ["ReadWriteOncePod"]. This requires a CSI driver that supports ReadWriteOncePod, and it
+  # must be the only access mode in the list. PersistentVolumeClaim accessModes are immutable, so this
+  # only takes effect for new installs / new PVCs, not via "helm upgrade" on an existing StatefulSet.
   pvcAccessModes: ["ReadWriteOnce"]
   ## @param orchestration.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
   # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -132,6 +132,18 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
 {{- end }}
 
 {{/*
+Fail with a message if orchestration.pvcAccessModes includes ReadWriteOncePod together with any
+other access mode. Kubernetes requires ReadWriteOncePod to be the sole access mode on a PVC.
+*/}}
+{{- if and (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) (gt (len .Values.orchestration.pvcAccessModes) 1) }}
+  {{- $errorMessage := printf "[camunda][error] %s %s"
+      "orchestration.pvcAccessModes includes \"ReadWriteOncePod\" together with another access mode."
+      "Kubernetes requires ReadWriteOncePod to be the only access mode in the list; set orchestration.pvcAccessModes to [\"ReadWriteOncePod\"] on its own."
+  -}}
+  {{ printf "\n%s" $errorMessage | trimSuffix "\n" | fail }}
+{{- end }}
+
+{{/*
 camunda.constraints.warnings
 Non-fatal deprecation/config warnings. Consumed by NOTES.txt (helm install/upgrade) and by
 configmap-warnings.yaml, which renders the "<release>-warnings" ConfigMap on the GitOps path
@@ -336,6 +348,15 @@ The following values inside your values.yaml need to be set but were not:
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}
 
+  {{- end }}
+
+  {{- if has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes }}
+    {{- $warningMessage := printf "%s %s %s"
+        "[camunda][warning]"
+        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; otherwise the PersistentVolumeClaim will remain stuck in Pending."
+        "PersistentVolumeClaim accessModes are immutable, so this only applies to new installs / new PVCs, not to an existing StatefulSet via \"helm upgrade\"."
+    -}}
+    {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
   {{- end }}
 {{- end }}
 

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -134,8 +134,13 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
 {{/*
 Fail with a message if orchestration.pvcAccessModes includes ReadWriteOncePod together with any
 other access mode. Kubernetes requires ReadWriteOncePod to be the sole access mode on a PVC.
+Only checked when a PVC is actually rendered, which mirrors the volumeClaimTemplates gate in
+templates/orchestration/statefulset.yaml.
 */}}
-{{- if and (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) (gt (len .Values.orchestration.pvcAccessModes) 1) }}
+{{- if and .Values.orchestration.enabled
+           (eq .Values.orchestration.persistenceType "disk")
+           (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes)
+           (gt (len .Values.orchestration.pvcAccessModes) 1) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
       "orchestration.pvcAccessModes includes \"ReadWriteOncePod\" together with another access mode."
       "Kubernetes requires ReadWriteOncePod to be the only access mode in the list; set orchestration.pvcAccessModes to [\"ReadWriteOncePod\"] on its own."
@@ -350,10 +355,12 @@ The following values inside your values.yaml need to be set but were not:
 
   {{- end }}
 
-  {{- if has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes }}
+  {{- if and .Values.orchestration.enabled
+             (eq .Values.orchestration.persistenceType "disk")
+             (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) }}
     {{- $warningMessage := printf "%s %s %s"
         "[camunda][warning]"
-        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; otherwise the PersistentVolumeClaim will remain stuck in Pending."
+        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; without that support the PersistentVolumeClaim may fail to provision or stay Pending."
         "PersistentVolumeClaim accessModes are immutable, so this only applies to new installs / new PVCs, not to an existing StatefulSet via \"helm upgrade\"."
     -}}
     {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -90,3 +90,42 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapWarningsTemplateTest) TestPvcAccessModesReadWriteOncePodWarning() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ReadWriteOncePodTriggersWarning",
+			Values: map[string]string{
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"],
+					"orchestration.pvcAccessModes is set to ReadWriteOncePod")
+			},
+		},
+		{
+			Name: "DefaultReadWriteOnceDoesNotTriggerWarning",
+			// Another warning must stay active so the ConfigMap still renders (it is omitted
+			// entirely when no warnings are present, see TestWarningsConfigMapAbsentWhenNoWarnings).
+			Values: map[string]string{
+				"identity.enabled":                                              "true",
+				"global.identity.auth.enabled":                                  "true",
+				"global.security.authentication.method":                         "oidc",
+				"connectors.security.authentication.oidc.secret.existingSecret": "foo",
+				"global.identity.auth.issuerBackendUrl":                         "http://keycloak:80/auth/realms/camunda-platform",
+				"global.testDeprecationFlags.existingSecretsMustBeSet":          "warning",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().NotContains(configmap.Data["warnings"], "pvcAccessModes")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/constraints_test.go
@@ -220,3 +220,29 @@ func (s *ConstraintTemplateTest) TestManagementIdentityExternalServiceUrl() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConstraintTemplateTest) TestPvcAccessModesReadWriteOncePodGuard() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ReadWriteOncePodAloneRenders",
+			Values: map[string]string{
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "ReadWriteOncePodWithAnotherAccessModeFails",
+			Values: map[string]string{
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Kubernetes requires ReadWriteOncePod to be the only access mode in the list")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/constraints_test.go
@@ -242,6 +242,30 @@ func (s *ConstraintTemplateTest) TestPvcAccessModesReadWriteOncePodGuard() {
 				s.Require().ErrorContains(err, "Kubernetes requires ReadWriteOncePod to be the only access mode in the list")
 			},
 		},
+		{
+			// pvcAccessModes is inert unless persistenceType renders a PVC, so an otherwise
+			// invalid combination must not block the install.
+			Name: "InvalidCombinationDoesNotFailWhenNoPvcIsRendered",
+			Values: map[string]string{
+				"orchestration.persistenceType":   "memory",
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "InvalidCombinationDoesNotFailWhenOrchestrationDisabled",
+			Values: map[string]string{
+				"orchestration.enabled":           "false",
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -3005,6 +3005,10 @@ orchestration:
   ## @param orchestration.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
   pvcSize: "32Gi"
   ## @param orchestration.pvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+  # For a storage-layer single-writer guarantee (instead of relying on pod anti-affinity alone), set
+  # this to ["ReadWriteOncePod"]. This requires a CSI driver that supports ReadWriteOncePod, and it
+  # must be the only access mode in the list. PersistentVolumeClaim accessModes are immutable, so this
+  # only takes effect for new installs / new PVCs, not via "helm upgrade" on an existing StatefulSet.
   pvcAccessModes: ["ReadWriteOnce"]
   ## @param orchestration.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
   # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -123,8 +123,13 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
 {{/*
 Fail with a message if orchestration.pvcAccessModes includes ReadWriteOncePod together with any
 other access mode. Kubernetes requires ReadWriteOncePod to be the sole access mode on a PVC.
+Only checked when a PVC is actually rendered, which mirrors the volumeClaimTemplates gate in
+templates/orchestration/statefulset.yaml.
 */}}
-{{- if and (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) (gt (len .Values.orchestration.pvcAccessModes) 1) }}
+{{- if and .Values.orchestration.enabled
+           (eq .Values.orchestration.persistenceType "disk")
+           (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes)
+           (gt (len .Values.orchestration.pvcAccessModes) 1) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
       "orchestration.pvcAccessModes includes \"ReadWriteOncePod\" together with another access mode."
       "Kubernetes requires ReadWriteOncePod to be the only access mode in the list; set orchestration.pvcAccessModes to [\"ReadWriteOncePod\"] on its own."
@@ -477,10 +482,12 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
   {{- end }}
 
-  {{- if has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes }}
+  {{- if and .Values.orchestration.enabled
+             (eq .Values.orchestration.persistenceType "disk")
+             (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) }}
     {{- $warningMessage := printf "%s %s %s"
         "[camunda][warning]"
-        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; otherwise the PersistentVolumeClaim will remain stuck in Pending."
+        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; without that support the PersistentVolumeClaim may fail to provision or stay Pending."
         "PersistentVolumeClaim accessModes are immutable, so this only applies to new installs / new PVCs, not to an existing StatefulSet via \"helm upgrade\"."
     -}}
     {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -121,6 +121,18 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
 {{- end }}
 
 {{/*
+Fail with a message if orchestration.pvcAccessModes includes ReadWriteOncePod together with any
+other access mode. Kubernetes requires ReadWriteOncePod to be the sole access mode on a PVC.
+*/}}
+{{- if and (has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes) (gt (len .Values.orchestration.pvcAccessModes) 1) }}
+  {{- $errorMessage := printf "[camunda][error] %s %s"
+      "orchestration.pvcAccessModes includes \"ReadWriteOncePod\" together with another access mode."
+      "Kubernetes requires ReadWriteOncePod to be the only access mode in the list; set orchestration.pvcAccessModes to [\"ReadWriteOncePod\"] on its own."
+  -}}
+  {{ printf "\n%s" $errorMessage | trimSuffix "\n" | fail }}
+{{- end }}
+
+{{/*
 camunda.constraints.warnings
 Non-fatal deprecation/config warnings. Consumed by NOTES.txt (helm install/upgrade) and by
 configmap-warnings.yaml, which renders the "<release>-warnings" ConfigMap on the GitOps path
@@ -463,6 +475,15 @@ The following values inside your values.yaml need to be set but were not:
       -}}
       {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
     {{- end }}
+  {{- end }}
+
+  {{- if has "ReadWriteOncePod" .Values.orchestration.pvcAccessModes }}
+    {{- $warningMessage := printf "%s %s %s"
+        "[camunda][warning]"
+        "orchestration.pvcAccessModes is set to ReadWriteOncePod, which requires a CSI driver that supports it; otherwise the PersistentVolumeClaim will remain stuck in Pending."
+        "PersistentVolumeClaim accessModes are immutable, so this only applies to new installs / new PVCs, not to an existing StatefulSet via \"helm upgrade\"."
+    -}}
+    {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
   {{- end }}
 {{- end }}
 

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -149,3 +149,40 @@ func mergeMaps(base map[string]string, overrides map[string]string) map[string]s
 	}
 	return merged
 }
+
+func (s *ConfigMapWarningsTemplateTest) TestPvcAccessModesReadWriteOncePodWarning() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ReadWriteOncePodTriggersWarning",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"orchestration.pvcAccessModes[0]":          "ReadWriteOncePod",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"],
+					"orchestration.pvcAccessModes is set to ReadWriteOncePod")
+			},
+		},
+		{
+			Name: "DefaultReadWriteOnceDoesNotTriggerWarning",
+			// Another warning must stay active so the ConfigMap still renders (it is omitted
+			// entirely when no warnings are present, see TestWarningsConfigMapAbsentWhenNoWarnings).
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"elasticsearch.enabled":                    "true",
+				"global.elasticsearch.enabled":             "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().NotContains(configmap.Data["warnings"], "pvcAccessModes")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
@@ -456,3 +456,29 @@ func (s *ConstraintTemplateTest) TestManagementIdentityExternalServiceUrl() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConstraintTemplateTest) TestPvcAccessModesReadWriteOncePodGuard() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ReadWriteOncePodAloneRenders",
+			Values: map[string]string{
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "ReadWriteOncePodWithAnotherAccessModeFails",
+			Values: map[string]string{
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Kubernetes requires ReadWriteOncePod to be the only access mode in the list")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
@@ -478,6 +478,30 @@ func (s *ConstraintTemplateTest) TestPvcAccessModesReadWriteOncePodGuard() {
 				s.Require().ErrorContains(err, "Kubernetes requires ReadWriteOncePod to be the only access mode in the list")
 			},
 		},
+		{
+			// pvcAccessModes is inert unless persistenceType renders a PVC, so an otherwise
+			// invalid combination must not block the install.
+			Name: "InvalidCombinationDoesNotFailWhenNoPvcIsRendered",
+			Values: map[string]string{
+				"orchestration.persistenceType":   "memory",
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "InvalidCombinationDoesNotFailWhenOrchestrationDisabled",
+			Values: map[string]string{
+				"orchestration.enabled":           "false",
+				"orchestration.pvcAccessModes[0]": "ReadWriteOncePod",
+				"orchestration.pvcAccessModes[1]": "ReadWriteOnce",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.9/values.yaml
+++ b/charts/camunda-platform-8.9/values.yaml
@@ -2841,6 +2841,10 @@ orchestration:
   ## @param orchestration.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
   pvcSize: "32Gi"
   ## @param orchestration.pvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+  # For a storage-layer single-writer guarantee (instead of relying on pod anti-affinity alone), set
+  # this to ["ReadWriteOncePod"]. This requires a CSI driver that supports ReadWriteOncePod, and it
+  # must be the only access mode in the list. PersistentVolumeClaim accessModes are immutable, so this
+  # only takes effect for new installs / new PVCs, not via "helm upgrade" on an existing StatefulSet.
   pvcAccessModes: ["ReadWriteOnce"]
   ## @param orchestration.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
   # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.


### PR DESCRIPTION
### Which problem does the PR fix?

Related to #7021.

Zeebe / Orchestration Cluster broker volumes default to `ReadWriteOnce` (RWO), which is node-scoped, not pod-scoped: depending on the CSI driver, more than one pod on the same node could mount and write to the same volume. We rely on the StatefulSet to prevent this right now, but it doesn't prevent other pods from mounting to the same node and modifying the files.

Investigation for #7021 confirmed that `orchestration.pvcAccessModes` already accepts `ReadWriteOncePod` (RWOP) today with **no code change required** (assuming the CSI driver supports it).

This PR does **not** change the default access mode. `PersistentVolumeClaim` `accessModes` are immutable in Kubernetes, so flipping the default would break `helm upgrade` for every existing 8.8/8.9/8.10 install (Kubernetes rejects the StatefulSet/PVC update outright). That's a breaking change requiring the project's Breaking Change Checklist (EM/PM + InfraEx) and is intentionally left for the self-managed team to decide on separately; this PR does not close #7021. That said, I highly recommend we try and make this the default for new deployments somehow if possible! I'll let you decide on whether it's good enough.

I learned from the Operator team that anyway it's possible even with RWOP that two pods write to the volume, so none of these are silver bullets...

### Changes

Applied identically to charts 8.8, 8.9, and 8.10:

- `values.yaml`: documents `ReadWriteOncePod` as an option on   `orchestration.pvcAccessModes`, noting the CSI driver requirement, that it must be the sole access mode, and that it only applies to new installs/PVCs (immutability).
- Non-fatal warning when `pvcAccessModes` includes `ReadWriteOncePod`, calling out the CSI driver requirement and PVC immutability.
- Hard `fail` guard when `ReadWriteOncePod` is combined with any other access mode, since Kubernetes requires it to be the sole mode on a PVC.

No default values changed, no golden files changed.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`. (not needed — no rendering change for default values)
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?