### PR TITLE
deps: update camunda/camunda:8.10-snapshot docker digest to 51dac5a

### DIFF
--- a/charts/camunda-platform-8.10/values-digest.yaml
+++ b/charts/camunda-platform-8.10/values-digest.yaml
@@ -49,7 +49,7 @@ orchestration:
   image:
     repository: camunda/camunda
     tag: 8.10-SNAPSHOT
-    digest: "sha256:6dbe2032c982380ce5964e5a29f73a3680ba9501f778d986634e66cf9209f823"
+    digest: "sha256:51dac5a18bb6b667ffcf32e4696b946e5a045055d9387540a5f186164e48863b"
 
 #
 # Identity


### PR DESCRIPTION
### Which problem does the PR fix?

SM-8.10 `identity-user-flows.spec.ts` › `User Roles User Flow on Orchestration Cluster` ›
`Assign Admin Role Permission to Test User` fails on every run that deploys the 8.10 chart —
nightly, and each connectors merge-queue / main Helm test:

- https://github.com/camunda/connectors/actions/runs/33613377131/job/100199486697
- https://github.com/camunda/connectors/actions/runs/33634366325

The Assign mapping rule dialog's search returns nothing, so the test times out clicking a
result that never renders. From the Playwright trace, both runs:

```
POST /orchestration/v2/mapping-rules/search
{"filter":{"name":{"$like":"*<mapping-rule-id>*"}}}
→ 400 {"detail":"Request property [filter.name] cannot be parsed"}
```

The dialog renders `mappingRulesCouldNotLoad` instead of options. Deterministic — all three
in-page retries and the Playwright retry fail identically.

The cause is a UI/backend version skew inside the pinned image, not a test defect:

| | Commit | Landed on `stable/8.10` |
|---|---|---|
| Identity UI starts sending `{"name":{"$like":...}}` | `c5b781a` | 2026-08-28 |
| Backend accepts `$like` on `filter.name` (`SearchQueryFilterMapper` → `nameOperations`) | `87ba55f` | 2026-09-01 08:06 |

The currently pinned `sha256:6dbe2032…` was built **2026-08-31 20:48** from rev `04530c0` —
inside that window, so it carries the new UI and the old request parser. It was pinned by
#6990 (merged 2026-09-01 07:34), 32 minutes before the backend fix merged.

### What's in this PR?

Bumps `orchestration.image.digest` for `charts/camunda-platform-8.10` to the current
`camunda/camunda:8.10-SNAPSHOT`:

- `sha256:51dac5a…`, built 2026-09-02 11:38 from rev `258d6cc`
- `git compare` puts `258d6cc` **240 commits ahead** of `87ba55f`, so it contains the fix

Digest resolved from the live registry (`docker-content-digest` for the `8.10-SNAPSHOT` tag)
at the time of commit; the manifest-list digest is used, matching the existing pin's form.
Only the 8.10 `orchestration` entry changes — no other component, chart, or version is touched.

Note for reviewers: `values-digest.yaml` is normally Renovate-owned (the
`camunda-platform-digests` group in `.github/renovate.json5`), and `AGENTS.md` lists it as a
generated artifact. This is a manual bump because no Renovate PR is open for this digest and
8.10 CI is red on every run until the pin moves; Renovate will reconcile the file on its next
run. If you would rather it come from the bot, close this and tick the re-run box on the
Dependency Dashboard (#39) instead.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
