### PR TITLE
deps: update camunda/camunda:8.10-snapshot docker digest to 69ffc86

### DIFF
--- a/charts/camunda-platform-8.10/values-digest.yaml
+++ b/charts/camunda-platform-8.10/values-digest.yaml
@@ -49,7 +49,7 @@ orchestration:
   image:
     repository: camunda/camunda
     tag: 8.10-SNAPSHOT
-    digest: "sha256:6dbe2032c982380ce5964e5a29f73a3680ba9501f778d986634e66cf9209f823"
+    digest: "sha256:69ffc86cf80cfb6a640748fa9868fdd13234b0832f3186f785fff01573d61cdf"
 
 #
 # Identity


### PR DESCRIPTION
### Which problem does the PR fix?

The 8.10 `orchestration` digest pin is 2 days stale and predates a product fix, which reds every
digest-pinned SM-8.10 AlwaysGreen run in downstream repos.

| | Digest | Built from | Date |
|---|---|---|---|
| Pinned (before) | `sha256:6dbe2032c982…` | `04530c0` | 2026-08-31 20:17 UTC |
| This PR | `sha256:69ffc86cf80c…` | `9593ebb` | 2026-09-03 06:39 UTC |

`camunda/camunda` commit `a46d7b9` ("implement `$like` search for roles/mapping rules", committed
**2026-09-01 07:42:54 UTC**) added `$like` support for `filter.name` on `POST /v2/mapping-rules/search`,
plus the missing `searchByMappingRuleId` entry in `identity/client/.../entitySelection.json`.

The current pin was merged in #6990 at **2026-09-01 07:34:44 UTC** — 8 minutes before that commit — so
it sits **10 commits behind** the fix. Identity's assign-mapping-rule dialog issues
`{"filter":{"name":{"$like":"*<id>*"}}}`, and the pinned backend answers:

```
400 {"title":"Bad Request","detail":"Request property [filter.name] cannot be parsed"}
```

The result-list option never renders, and SM-8.10 `identity-user-flows.spec.ts` ›
*User Roles User Flow on Orchestration Cluster* › **Assign Admin Role Permission to Test User**
fails deterministically (all 3 attempts, both retries).

Confirmed in consecutive `camunda/connectors` merge-queue runs:
[33634366325](https://github.com/camunda/connectors/actions/runs/33634366325) (09-02) and
[33730581679](https://github.com/camunda/connectors/actions/runs/33730581679) (09-03).
Both log `Including chart-root overlay overlay=digest` with `componentsOverridden=["connectors"]`, so
only the connectors pin is stripped and orchestration stays on `6dbe2032`.

The same spec passes wherever orchestration is **not** digest-pinned:

- `camunda/camunda` 8.10 AlwaysGreen [33726233187](https://github.com/camunda/camunda/actions/runs/33726233187)
  builds orchestration from `9593ebb` and reports `20 passed`.
- SM-8.10 nightly [33579704117](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/33579704117)
  resolves the live `8.10-SNAPSHOT` tag and passes the step in 8.0s.

So 8.10 at HEAD is healthy; only the pin is behind.

### What's in this PR?

One line: the 8.10 `orchestration.image.digest` moves from `sha256:6dbe2032c982…` to
`sha256:69ffc86cf80c…` (`9593ebb`, 364 commits ahead of `a46d7b9`). No other pin, template, or golden
is touched — #6990 shows a digest bump is confined to this file.

**Why this is a manual edit, and why it needs a decision.** `.github/escalation-policy.md` says never
to hand-edit `values-digest.yaml`, and `.github/instructions/code-review.instructions.md` tells
reviewers not to approve one. This PR is opened deliberately against that rule because the owning
automation cannot currently land the bump:

The `camunda-platform-digests` rule carries `minimumReleaseAge: '6 hours'`, and with
`recreateWhen: 'always'` Renovate re-evaluates each pin against the tag's *current* digest on every
pass — it does not hold a previously-eligible one. `camunda/camunda:8.10-SNAPSHOT` was re-pushed four
times in under 24h (09-02 11:38, 17:10, 23:32; 09-03 07:33), so the soak keeps resetting:

- the 09-02 11:38 digest reached 5h32m — replaced 28 minutes short;
- the 09-02 23:32 digest (`7ea7ee66`) *did* clear 6h at 05:32 and was added to #7026, but that PR was
  red the whole window (`Local cluster - KIND 8.10/8.8` failing in `asdf-install` with
  `git exit code 128`, at 06:08);
- at 07:17 Renovate rewrote the branch and **dropped** the `camunda/camunda` bump; #7026 now bumps only
  `connectors-bundle`, so merging it would not fix this.

Net: the pin has been unchanged for 49h while every affected merge-queue run fails.

If maintainers would rather not take a manual edit, the durable alternative is to exempt
`camunda/camunda` from `minimumReleaseAge` (or lower it to ~1h for that pin) — a 6-hour soak is
unsatisfiable for the fastest-churning tag in this file during working hours. Happy to close this in
favour of that change; it needs an owner decision either way. The KIND `asdf-install` flake is worth
fixing separately, since it blocks every digests automerge regardless of the soak.

Note this tag moves roughly hourly, so `69ffc86c` may not be the newest by review time. Any digest at
or after `a46d7b9` resolves the failure.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
