### PR TITLE
fix(8.9): keep camundaexporter registration for legacy exporter args

### DIFF
--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -318,6 +318,19 @@ falls through to the shared global/secondary-storage sources otherwise.
 {{- end -}}
 
 
+{{- /*
+NOTE: 8.9 keeps the explicit CamundaExporter registration even though
+`camunda.data.secondary-storage.autoconfigure-camunda-exporter` auto-registers the same exporter
+(the redundancy costs a legacy-property warning at startup). Customers on the released 8.9 line
+inject legacy overrides as `ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_*` environment variables,
+which Spring merges into this same map; without the `className` this block supplies, the broker
+refuses to start. See helm#7028. The 8.10 application merges legacy exporter args on its own, so
+the registration stays removed there.
+*/ -}}
+{{- define "orchestration.hasCamundaExporter" -}}
+{{- and (not (eq (include "orchestration.secondaryStorage" .) "none")) .Values.orchestration.exporters.camunda.enabled (not .Values.orchestration.exporters.rdbms.enabled) -}}
+{{- end -}}
+
 {{- define "orchestration.hasElasticsearchExporter" -}}
 {{- and
       (or

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -116,16 +116,10 @@ camunda:
         password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
         index-prefix: {{ .Values.orchestration.index.prefix | quote }}
         number-of-replicas: {{ .Values.orchestration.index.replicas | quote }}
+        {{- if .Values.orchestration.history.retention.enabled }}
         history:
-          els-rollover-date-format: {{ .Values.orchestration.history.elsRolloverDateFormat | quote }}
-          rollover-interval: {{ .Values.orchestration.history.rolloverInterval | quote }}
-          rollover-batch-size: {{ .Values.orchestration.history.rolloverBatchSize }}
-          wait-period-before-archiving: {{ .Values.orchestration.history.waitPeriodBeforeArchiving | quote }}
-          delay-between-runs: {{ .Values.orchestration.history.delayBetweenRuns }}
-          max-delay-between-runs: {{ .Values.orchestration.history.maxDelayBetweenRuns }}
-          {{- if .Values.orchestration.history.retention.enabled }}
           policy-name: {{ .Values.orchestration.history.retention.policyName | quote }}
-          {{- end }}
+        {{- end }}
       {{- end }}
       {{- if or .Values.global.opensearch.enabled .Values.optimize.database.opensearch.enabled (eq .Values.orchestration.data.secondaryStorage.type "opensearch") }}
       opensearch:
@@ -136,16 +130,10 @@ camunda:
         password: "${VALUES_OPENSEARCH_PASSWORD:}"
         index-prefix: {{ .Values.orchestration.index.prefix | quote }}
         number-of-replicas: {{ .Values.orchestration.index.replicas | quote }}
+        {{- if .Values.orchestration.history.retention.enabled }}
         history:
-          els-rollover-date-format: {{ .Values.orchestration.history.elsRolloverDateFormat | quote }}
-          rollover-interval: {{ .Values.orchestration.history.rolloverInterval | quote }}
-          rollover-batch-size: {{ .Values.orchestration.history.rolloverBatchSize }}
-          wait-period-before-archiving: {{ .Values.orchestration.history.waitPeriodBeforeArchiving | quote }}
-          delay-between-runs: {{ .Values.orchestration.history.delayBetweenRuns }}
-          max-delay-between-runs: {{ .Values.orchestration.history.maxDelayBetweenRuns }}
-          {{- if .Values.orchestration.history.retention.enabled }}
           policy-name: {{ .Values.orchestration.history.retention.policyName | quote }}
-          {{- end }}
+        {{- end }}
       {{- end }}
       {{- if .Values.orchestration.exporters.rdbms.enabled }}
       rdbms:
@@ -330,6 +318,7 @@ zeebe:
     {{- if or
       (eq (include "orchestration.hasElasticsearchExporter" .) "true")
       (eq (include "orchestration.hasOpenSearchExporter" .) "true")
+      (eq (include "orchestration.hasCamundaExporter" .) "true")
       (eq (include "orchestration.hasAppIntegrations" .) "true")
     }}
     # zeebe.broker.exporters
@@ -377,6 +366,24 @@ zeebe:
             minimumAge: {{ .Values.orchestration.retention.minimumAge | quote }}
             policyName: {{ .Values.orchestration.retention.policyName | quote }}
           {{- end }}
+    {{- end }}
+    {{- if eq (include "orchestration.hasCamundaExporter" .) "true" }}
+      camundaexporter:
+        className: "io.camunda.exporter.CamundaExporter"
+        args:
+          connect:
+            type: {{ include "orchestration.secondaryStorage" . | quote }}
+            {{- if .Values.orchestration.index.prefix }}
+            indexPrefix: {{ .Values.orchestration.index.prefix | quote }}
+            {{- end }}
+            awsEnabled: {{ or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
+          history:
+            elsRolloverDateFormat: {{ .Values.orchestration.history.elsRolloverDateFormat | quote }}
+            rolloverInterval: {{ .Values.orchestration.history.rolloverInterval | quote }}
+            rolloverBatchSize: {{ .Values.orchestration.history.rolloverBatchSize }}
+            waitPeriodBeforeArchiving: {{ .Values.orchestration.history.waitPeriodBeforeArchiving | quote }}
+            delayBetweenRuns: {{ .Values.orchestration.history.delayBetweenRuns }}
+            maxDelayBetweenRuns: {{ .Values.orchestration.history.maxDelayBetweenRuns }}
     {{- end }}
     {{- if eq (include "orchestration.hasAppIntegrations" .) "true" }}
       appIntegrations:

--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -316,6 +316,21 @@ integration:
           persistence: elasticsearch
           features:
             - persistence
+        - name: legacy-exporter-args
+          enabled: true
+          shortname: lgexp
+          auth: keycloak
+          flow: install,upgrade-patch
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - legacy-exporter-args
         - name: keycloak-original
           enabled: true
           shortname: keyco

--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -320,7 +320,7 @@ integration:
           enabled: true
           shortname: lgexp
           auth: keycloak
-          flow: install,upgrade-patch
+          flow: install
           platforms:
             - gke
           exclude: []

--- a/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
@@ -81,6 +81,13 @@ integration:
       shortname: cprst
       tier: 2
       enabled: true
+    # helm#7028 regression guard: legacy ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_*
+    # overrides must survive a patch upgrade. Step 1 installs the latest published 8.9
+    # patch, so this cell stays red until 14.9.1 replaces the broken 14.9.0 as that source.
+    - id: legacy-exporter-args
+      shortname: lgexp
+      tier: 2
+      enabled: true
     - id: keycloak-original-install-tier1
       shortname: keyco
       tier: 1

--- a/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
@@ -81,9 +81,9 @@ integration:
       shortname: cprst
       tier: 2
       enabled: true
-    # helm#7028 regression guard: legacy ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_*
-    # overrides must survive a patch upgrade. Step 1 installs the latest published 8.9
-    # patch, so this cell stays red until 14.9.1 replaces the broken 14.9.0 as that source.
+    # helm#7028 regression guard: an install carrying legacy
+    # ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_* overrides must start. The upgrade-patch
+    # flow is added once 14.9.1 is published (see scenarios/legacy-exporter-args.yaml).
     - id: legacy-exporter-args
       shortname: lgexp
       tier: 2

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/legacy-exporter-args.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/legacy-exporter-args.yaml
@@ -1,0 +1,12 @@
+name: legacy-exporter-args
+auth: keycloak
+flows:
+  - install,upgrade-patch
+identity: keycloak
+persistence: elasticsearch
+features:
+  - legacy-exporter-args
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/legacy-exporter-args.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/legacy-exporter-args.yaml
@@ -1,7 +1,9 @@
 name: legacy-exporter-args
 auth: keycloak
+# upgrade-patch is added once 14.9.1 is published: Step 1 installs the latest published
+# 8.9 patch, which is the broken 14.9.0 until then. See helm#7028.
 flows:
-  - install,upgrade-patch
+  - install
 identity: keycloak
 persistence: elasticsearch
 features:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/legacy-exporter-args.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/legacy-exporter-args.yaml
@@ -1,0 +1,9 @@
+# Reproduces the customer shape from helm#7028: legacy Camunda exporter arguments
+# injected as environment variables. Spring merges these into
+# zeebe.broker.exporters.camundaexporter, which the chart must keep registering with a
+# className — otherwise the broker refuses to start with "Expected to find a 'className'
+# configured for the exporter".
+orchestration:
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_HISTORY_ROLLOVERBATCHSIZE
+      value: "321"

--- a/charts/camunda-platform-8.9/test/unit/common/types.go
+++ b/charts/camunda-platform-8.9/test/unit/common/types.go
@@ -40,7 +40,28 @@ type ElasticsearchYAML struct {
 }
 
 type CamundaExporterYAML struct {
-	ClassName string `yaml:"className"`
+	ClassName string                  `yaml:"className"`
+	Args      CamundaExporterArgsYAML `yaml:"args"`
+}
+
+type CamundaExporterArgsYAML struct {
+	Connect CamundaExporterConnectYAML `yaml:"connect"`
+	History CamundaExporterHistoryYAML `yaml:"history"`
+}
+
+type CamundaExporterConnectYAML struct {
+	Type        string `yaml:"type"`
+	IndexPrefix string `yaml:"indexPrefix"`
+	AwsEnabled  bool   `yaml:"awsEnabled"`
+}
+
+type CamundaExporterHistoryYAML struct {
+	ElsRolloverDateFormat     string `yaml:"elsRolloverDateFormat"`
+	RolloverInterval          string `yaml:"rolloverInterval"`
+	RolloverBatchSize         int    `yaml:"rolloverBatchSize"`
+	WaitPeriodBeforeArchiving string `yaml:"waitPeriodBeforeArchiving"`
+	DelayBetweenRuns          int    `yaml:"delayBetweenRuns"`
+	MaximumDelayBetweenRuns   int    `yaml:"maxDelayBetweenRuns"`
 }
 
 type GatewayYAML struct {
@@ -87,13 +108,11 @@ type DocumentSecondaryStoreYAML struct {
 	History HistoryYAML `yaml:"history"`
 }
 
+// HistoryYAML mirrors camunda.data.secondary-storage.<store>.history, which carries only the
+// retention policy name on the 8.9 line; the archiver settings live in the legacy
+// zeebe.broker.exporters.camundaexporter.args.history block (see helm#7028).
 type HistoryYAML struct {
-	ElsRolloverDateFormat     string `yaml:"els-rollover-date-format"`
-	RolloverInterval          string `yaml:"rollover-interval"`
-	RolloverBatchSize         int    `yaml:"rollover-batch-size"`
-	WaitPeriodBeforeArchiving string `yaml:"wait-period-before-archiving"`
-	DelayBetweenRuns          int    `yaml:"delay-between-runs"`
-	MaximumDelayBetweenRuns   int    `yaml:"max-delay-between-runs"`
+	PolicyName string `yaml:"policy-name"`
 }
 
 type IdentityYAML struct {

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
@@ -131,7 +131,11 @@ func TestGoldenConfigmapWithRDBMSEnabled(t *testing.T) {
 func (s *ConfigmapLegacyTemplateTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name:   "TestExportersShouldBeEmptyByDefault",
+			// The explicit registration must stay: customers on the released 8.9 line inject
+			// ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_* overrides that Spring merges into
+			// this map, and the broker refuses to start when the entry has args but no
+			// className. See helm#7028.
+			Name:   "TestContainerShouldContainExporterClassPerDefault",
 			Values: map[string]string{},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -139,25 +143,66 @@ func (s *ConfigmapLegacyTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 				helm.UnmarshalK8SYaml(s.T(), configmap.Data["application.yaml"], &configmapApplication)
 
-				// CamundaExporter is auto-registered via autoconfigure-camunda-exporter: true;
-				// the legacy zeebe.broker.exporters.camundaexporter entry must not be present.
-				s.Require().Empty(configmapApplication.Zeebe.Broker.Exporters.CamundaExporter.ClassName)
+				s.Require().Equal("io.camunda.exporter.CamundaExporter", configmapApplication.Zeebe.Broker.Exporters.CamundaExporter.ClassName)
 
 				s.Require().NotContains(configmap.Data["application.yaml"], "exporters: {}")
 			},
 		},
 		{
-			Name:   "TestCustomHistorySettingsUseUnifiedElasticsearchConfig",
-			Values: customHistoryValues("elasticsearch"),
+			// A legacy args override on its own cannot supply a className, so the chart must
+			// keep rendering one alongside it. See helm#7028.
+			Name: "TestExporterClassIsRenderedAlongsideLegacyArgsOverride",
+			Values: map[string]string{
+				"orchestration.env[0].name":  "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_HISTORY_ELSROLLOVERDATEFORMAT",
+				"orchestration.env[0].value": "yyyy-MM",
+			},
 			Verifier: func(t *testing.T, output string, err error) {
-				assertCustomHistorySettings(t, output, false)
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				var configmapApplication camunda.OrchestrationApplicationYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				helm.UnmarshalK8SYaml(s.T(), configmap.Data["application.yaml"], &configmapApplication)
+
+				s.Require().Equal("io.camunda.exporter.CamundaExporter", configmapApplication.Zeebe.Broker.Exporters.CamundaExporter.ClassName)
 			},
 		},
 		{
-			Name:   "TestCustomHistorySettingsUseUnifiedOpenSearchConfig",
+			Name:   "TestCustomHistorySettingsUseLegacyExporterArgsWithElasticsearch",
+			Values: customHistoryValues("elasticsearch"),
+			Verifier: func(t *testing.T, output string, err error) {
+				assertCustomHistorySettings(t, output, "elasticsearch")
+			},
+		},
+		{
+			Name:   "TestCustomHistorySettingsUseLegacyExporterArgsWithOpenSearch",
 			Values: customHistoryValues("opensearch"),
 			Verifier: func(t *testing.T, output string, err error) {
-				assertCustomHistorySettings(t, output, true)
+				assertCustomHistorySettings(t, output, "opensearch")
+			},
+		},
+		{
+			// The archiver settings belong to the legacy exporter args on the 8.9 line; the
+			// unified secondary-storage history block carries only the retention policy name.
+			Name: "TestUnifiedHistoryCarriesOnlyRetentionPolicyName",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":    "elasticsearch",
+				"orchestration.history.retention.enabled":     "true",
+				"orchestration.history.retention.policyName":  "custom-policy",
+				"orchestration.history.elsRolloverDateFormat": "yyyy-MM",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				var application camunda.OrchestrationApplicationYAML
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+				require.NoError(t, yaml.Unmarshal([]byte(applicationYaml), &application))
+
+				require.Equal(t, "custom-policy", application.Camunda.Data.SecondaryStorage.Elasticsearch.History.PolicyName)
+				require.NotContains(t, applicationYaml, "els-rollover-date-format:")
+				require.NotContains(t, applicationYaml, "rollover-batch-size:")
 			},
 		},
 		{
@@ -206,17 +251,18 @@ func assertCamundaExporterAutoconfiguration(t *testing.T, output string, expecte
 	require.Equal(t, expected, application.Camunda.Data.SecondaryStorage.AutoconfigureCamundaExporter)
 }
 
-func assertCustomHistorySettings(t *testing.T, output string, openSearch bool) {
+func assertCustomHistorySettings(t *testing.T, output string, secondaryStorageType string) {
 	var configmap corev1.ConfigMap
 	var application camunda.OrchestrationApplicationYAML
 	helm.UnmarshalK8SYaml(t, output, &configmap)
 	require.NoError(t, yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &application))
 	require.NotContains(t, configmap.Data["application.yaml"], "camundaexporter:")
 
-	history := application.Camunda.Data.SecondaryStorage.Elasticsearch.History
-	if openSearch {
-		history = application.Camunda.Data.SecondaryStorage.OpenSearch.History
-	}
+	exporter := application.Zeebe.Broker.Exporters.CamundaExporter
+	require.Equal(t, "io.camunda.exporter.CamundaExporter", exporter.ClassName)
+	require.Equal(t, secondaryStorageType, exporter.Args.Connect.Type)
+
+	history := exporter.Args.History
 	require.Equal(t, "yyyy-MM", history.ElsRolloverDateFormat)
 	require.Equal(t, "2d", history.RolloverInterval)
 	require.Equal(t, 321, history.RolloverBatchSize)

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
@@ -256,7 +256,6 @@ func assertCustomHistorySettings(t *testing.T, output string, secondaryStorageTy
 	var application camunda.OrchestrationApplicationYAML
 	helm.UnmarshalK8SYaml(t, output, &configmap)
 	require.NoError(t, yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &application))
-	require.NotContains(t, configmap.Data["application.yaml"], "camundaexporter:")
 
 	exporter := application.Zeebe.Broker.Exporters.CamundaExporter
 	require.Equal(t, "io.camunda.exporter.CamundaExporter", exporter.ClassName)

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -106,13 +106,6 @@ data:
             password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
             index-prefix: ""
             number-of-replicas: "1"
-            history:
-              els-rollover-date-format: "date"
-              rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
-              delay-between-runs: 2000
-              max-delay-between-runs: 60000
     
       # Security configuration - Separated syntax.
       security:
@@ -197,5 +190,20 @@ data:
         # zeebe.broker.cluster
         cluster:
           clusterName: camunda-platform-test-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
     
   log4j2.xml: |

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -106,13 +106,6 @@ data:
             password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
             index-prefix: ""
             number-of-replicas: "1"
-            history:
-              els-rollover-date-format: "date"
-              rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
-              delay-between-runs: 2000
-              max-delay-between-runs: 60000
     
       # Security configuration - Separated syntax.
       security:
@@ -197,6 +190,21 @@ data:
         # zeebe.broker.cluster
         cluster:
           clusterName: camunda-platform-test-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
     
   log4j2.xml: |
     <xml>

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -110,12 +110,6 @@ data:
             index-prefix: ""
             number-of-replicas: "1"
             history:
-              els-rollover-date-format: "date"
-              rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
-              delay-between-runs: 2000
-              max-delay-between-runs: 60000
               policy-name: "camunda-history-retention-policy"
     
       # Security configuration - Separated syntax.
@@ -207,5 +201,20 @@ data:
         # zeebe.broker.cluster
         cluster:
           clusterName: camunda-platform-test-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
     
   log4j2.xml: |

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
@@ -106,13 +106,6 @@ data:
             password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
             index-prefix: ""
             number-of-replicas: "1"
-            history:
-              els-rollover-date-format: "date"
-              rollover-interval: "1d"
-              rollover-batch-size: 100
-              wait-period-before-archiving: "1h"
-              delay-between-runs: 2000
-              max-delay-between-runs: 60000
     
       # Security configuration - Separated syntax.
       security:
@@ -197,5 +190,20 @@ data:
         # zeebe.broker.cluster
         cluster:
           clusterName: camunda-platform-test-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
     
   log4j2.xml: |

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -555,13 +555,17 @@ func TestGenerateWithRealConfigs(t *testing.T) {
 		t.Errorf("Generate: expected entries for at least 2 versions, got %d: %v", len(versions), versions)
 	}
 
-	// Verify no denied flows leaked through (must stay in sync with permitted-flows.yaml)
+	// Verify no denied flows leaked through. Derived from permitted-flows.yaml rather than
+	// hardcoded: the deny rules move as minors are released (upgrade-patch was denied for
+	// 8.9 while it was unreleased, and now only for 8.10), and a hardcoded copy silently
+	// goes stale because it only fires once a scenario declares the flow.
+	pf, err := LoadPermittedFlows(repoRoot)
+	if err != nil {
+		t.Fatalf("LoadPermittedFlows: %v", err)
+	}
 	for _, e := range entries {
-		if e.Version == "8.9" && e.Flow == "upgrade-patch" {
-			t.Errorf("Generate: 8.9 entry has denied flow %q (scenario=%s)", e.Flow, e.Scenario)
-		}
-		if (e.Version == "8.6" || e.Version == "8.7") && e.Flow == "upgrade-minor" {
-			t.Errorf("Generate: %s entry has denied flow upgrade-minor (scenario=%s)", e.Version, e.Scenario)
+		if len(FilterFlows(pf, e.Version, []string{e.Flow})) == 0 {
+			t.Errorf("Generate: %s entry has denied flow %q (scenario=%s)", e.Version, e.Flow, e.Scenario)
 		}
 	}
 


### PR DESCRIPTION
Fixes #7028

### Which problem does the PR fix?

Chart 14.9.0 removed the explicit `zeebe.broker.exporters.camundaexporter` registration (#6454),
because the application auto-registers the Camunda exporter through
`camunda.data.secondary-storage.autoconfigure-camunda-exporter`.

Customers who inject legacy exporter arguments as environment variables — for example
`ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_HISTORY_ROLLOVERBATCHSIZE` — relied on the chart to
supply the matching `className`. Spring merges those variables into the same exporter map, so
without the chart's entry the map has `args` but no `className` and the broker refuses to start:

```text
Expected to find a 'className' configured for the exporter.
Couldn't find a valid one for the following exporters [camundaexporter]
```

This is a released user-facing regression on the 8.9 line.

### What's in this PR?

Reverts the 14.9.0 behaviour change on 8.9 only:

- Restores `zeebe.broker.exporters.camundaexporter` and the `orchestration.hasCamundaExporter`
  helper.
- Moves the six `orchestration.history.*` archiver settings back from
  `camunda.data.secondary-storage.<store>.history.*` to the exporter args, so the two paths do not
  configure the same settings twice. The unified block keeps only `policy-name`, gated on
  `retention.enabled`, exactly as before 14.9.0.

`templates/orchestration/files/_application.yaml` now differs from its pre-#6454 state only by the
cosmetic `hasLegacyElasticsearchExporter` → `hasElasticsearchExporter` helper renames, which are
left in place.

**8.10 is deliberately untouched** — the 8.10 application merges legacy exporter args itself, so the
registration stays removed there.

A patch release should not have carried this cleanup in the first place; that is the root cause, and
this restores the 8.9 contract.

### Upgrade mitigation for anyone already on 14.9.0

Add the class name to the same environment source that supplies the legacy arguments — this works
today, without waiting for 14.9.1:

```yaml
orchestration:
  env:
    - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME
      value: "io.camunda.exporter.CamundaExporter"
```

The same applies to arguments injected via `orchestration.envFrom` or any external mechanism: add
`ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME` to that ConfigMap or Secret. Installs that use
only `orchestration.history.*` were never affected.

### Tests

- Restored `TestContainerShouldContainExporterClassPerDefault`; added
  `TestExporterClassIsRenderedAlongsideLegacyArgsOverride` (the issue's reproduction) and
  `TestUnifiedHistoryCarriesOnlyRetentionPolicyName`; retargeted the custom-history cases at the
  exporter args.
- Regenerated the four affected configmap goldens (a clean inverse of #6454).
- New `legacy-exporter-args` CI scenario (`lgexp`, tier 2, `install`) carrying the legacy
  environment variable, so a live deployment proves the broker starts with this override.
- Fixed a stale assertion in `TestGenerateWithRealConfigs` that hardcoded "8.9 denies
  upgrade-patch". That was true while 8.9 was unreleased; `permitted-flows.yaml` has since moved
  the deny to 8.10. The check now derives from the config so it cannot drift again.

### Known CI state

The scenario runs the `install` flow only. `upgrade-patch` installs the **latest published** 8.9
patch in Step 1, which is the broken 14.9.0 — that cell cannot pass until this fix is itself
published, and since the merge queue runs all tiers it would block its own release. Adding
`upgrade-patch` to the scenario's flows is a follow-up once 14.9.1 is out; the scenario file and
manifest both carry a comment saying so.

The 8.10 `kemt` cross-minor cell reaches the 8.9 chart through the published repo too, so it stays
red for the same reason until 14.9.1 lands. Testing a local previous-version chart in Step 1 is
tracked in #7027 and would remove this class of chicken-and-egg entirely.

Local validation:

- `make go.test chartPath=charts/camunda-platform-8.9`
- `make helm.lint chartPath=charts/camunda-platform-8.9`
- `cd scripts/deploy-camunda && go test ./matrix/`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
