### PR TITLE
ci: retry cosign sign-blob on transient sigstore errors

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -528,7 +528,7 @@ jobs:
           # helm push with retry and re-auth (most common 401 failure point)
           harbor_retry "helm push" helm push "${HELM_PACKAGE}" "oci://${OCI_REGISTRY}"
 
-          cosign sign-blob -y ${HELM_PACKAGE} \
+          retry_cmd "cosign sign-blob" cosign sign-blob -y ${HELM_PACKAGE} \
             --bundle ".cr-release-packages/${{ env.CHART_RELEASE_COSIGN_BUNDLE_FILE }}"
 
           CHART_RELEASE_TAG_NAME="camunda-platform-${{ matrix.chart.version }}-${RELEASE_VERSION}"

--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -528,7 +528,7 @@ jobs:
           # helm push with retry and re-auth (most common 401 failure point)
           harbor_retry "helm push" helm push "${HELM_PACKAGE}" "oci://${OCI_REGISTRY}"
 
-          retry_cmd "cosign sign-blob" cosign sign-blob -y ${HELM_PACKAGE} \
+          retry_cmd "cosign sign-blob" cosign sign-blob -y "${HELM_PACKAGE}" \
             --bundle ".cr-release-packages/${{ env.CHART_RELEASE_COSIGN_BUNDLE_FILE }}"
 
           CHART_RELEASE_TAG_NAME="camunda-platform-${{ matrix.chart.version }}-${RELEASE_VERSION}"

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -242,7 +242,8 @@ jobs:
         if: ${{ !inputs.dry-run }}
         working-directory: .cr-release-packages
         run: |
-          cosign sign-blob -y "${{ steps.metadata.outputs.package_file }}" \
+          source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
+          retry_cmd "cosign sign-blob" cosign sign-blob -y "${{ steps.metadata.outputs.package_file }}" \
             --bundle "${{ steps.metadata.outputs.cosign_bundle }}"
 
       - name: Get Cosign Rekor log index

--- a/scripts/harbor-retry.sh
+++ b/scripts/harbor-retry.sh
@@ -22,6 +22,7 @@
 # Usage:
 #   source scripts/harbor-retry.sh
 #   harbor_retry "helm push" helm push chart.tgz oci://registry/project
+#   retry_cmd "cosign sign-blob" cosign sign-blob -y chart.tgz --bundle chart.bundle
 #   harbor_login   # login with retry
 
 HARBOR_RETRY_MAX=${HARBOR_RETRY_MAX:-3}
@@ -65,6 +66,29 @@ harbor_retry() {
     if [[ ${attempt} -lt ${max_retries} ]]; then
       echo "::warning::${desc} failed on attempt ${attempt}, re-authenticating and retrying in ${retry_delay}s..."
       harbor_reauth || echo "::warning::Re-authentication also failed (attempt ${attempt}), will retry after backoff..."
+      sleep "${retry_delay}"
+      retry_delay=$((retry_delay * 2))
+    fi
+  done
+
+  echo "::error::${desc} failed after ${max_retries} attempts"
+  return 1
+}
+
+# Retry a command with exponential backoff, no re-auth.
+# Usage: retry_cmd <description> <command ...>
+retry_cmd() {
+  local desc="$1"; shift
+  local max_retries=${HARBOR_RETRY_MAX}
+  local retry_delay=${HARBOR_RETRY_DELAY}
+
+  for attempt in $(seq 1 "${max_retries}"); do
+    echo "=== ${desc} (attempt ${attempt}/${max_retries}) ==="
+    if "$@"; then
+      return 0
+    fi
+    if [[ ${attempt} -lt ${max_retries} ]]; then
+      echo "::warning::${desc} failed on attempt ${attempt}, retrying in ${retry_delay}s..."
       sleep "${retry_delay}"
       retry_delay=$((retry_delay * 2))
     fi


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6438.

### What's in this PR?

`cosign sign-blob` in the dev-build and public-release workflows runs without retry, unlike the adjacent `helm push` / `oras push` calls. Every recent `Push Helm chart to Harbor` failure with surviving logs died on this call with a transient Sigstore-side error: ambient OIDC token returned as non-JSON, `timestamp.sigstore.dev` connection reset, TUF root download 403.

- `scripts/harbor-retry.sh`: add `retry_cmd`, the `harbor_retry` backoff loop without the Harbor re-auth step. Re-auth is not the remedy for Sigstore failures, and the public-release sign step has no Harbor credentials in env.
- `chart-build-dev.yaml`: wrap `cosign sign-blob` in `retry_cmd`.
- `chart-release-public.yaml`: source the helper and wrap `cosign sign-blob` in `retry_cmd`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
