### PR TITLE
ci: exempt snapshot digest pins from minimumReleaseAge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -369,6 +369,7 @@
       versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-9]))$',
     },
     {
+      description: 'Digest pins age against the tag\'s tag_last_pushed, not the digest, so a SNAPSHOT tag re-pushed hourly can never satisfy a release-age soak; snapshot pins carry none.',
       enabled: true,
       groupName: 'camunda-platform-digests',
       matchPackageNames: [
@@ -388,6 +389,24 @@
       schedule: ['at any time'],
       prCreation: 'immediate',
       addLabels: ['camunda-platform', 'priority-high'],
+    },
+    {
+      description: 'Release tags and latest are expected to be immutable; a moved digest there is a re-publish, so hold it for six hours before pinning.',
+      matchPackageNames: [
+        '/.*camunda.*/',
+      ],
+      matchDatasources: [
+        'helm',
+        'docker',
+        'regex',
+      ],
+      matchFileNames: [
+        'charts/camunda-platform-8.8/values-digest.yaml',
+        'charts/camunda-platform-8.9/values-digest.yaml',
+        'charts/camunda-platform-8.10/values-digest.yaml',
+      ],
+      matchUpdateTypes: ['digest'],
+      matchCurrentValue: '!/SNAPSHOT/',
       minimumReleaseAge: '6 hours',
     },
     {

--- a/scripts/renovate-config-check/renovate_config_test.go
+++ b/scripts/renovate-config-check/renovate_config_test.go
@@ -57,6 +57,7 @@ type PackageRule struct {
 	MatchManagers     []string `json:"matchManagers"`
 	MatchPackageNames []string `json:"matchPackageNames"`
 	MatchUpdateTypes  []string `json:"matchUpdateTypes"`
+	MatchCurrentValue string   `json:"matchCurrentValue"`
 	PRCreation        string   `json:"prCreation"`
 	MinimumReleaseAge string   `json:"minimumReleaseAge"`
 	AddLabels         []string `json:"addLabels"`
@@ -274,18 +275,67 @@ func TestGitHubActionsAutomergePolicy(t *testing.T) {
 func TestDigestUpdatePolicy(t *testing.T) {
 	config := readRenovateConfig(t)
 
-	for _, rule := range config.PackageRules {
-		if rule.GroupName != "camunda-platform-digests" {
-			continue
+	group, guard := digestRules(t, config)
+
+	assert.Contains(t, group.MatchUpdateTypes, "digest")
+	assert.Equal(t, "immediate", group.PRCreation,
+		"moving snapshot digests must not be held by the global not-pending policy")
+	assert.Empty(t, group.MatchCurrentValue)
+	assert.Empty(t, group.MinimumReleaseAge,
+		"a release-age soak on the group ages the tag, not the digest, and is never met by a re-pushed SNAPSHOT tag")
+
+	assert.Contains(t, guard.MatchUpdateTypes, "digest")
+	assert.Equal(t, group.MatchFileNames, guard.MatchFileNames)
+	assert.Equal(t, "!/SNAPSHOT/", guard.MatchCurrentValue)
+	assert.Equal(t, "6 hours", guard.MinimumReleaseAge,
+		"digest moves on release tags need time to detect re-published image hashes")
+}
+
+func TestSnapshotDigestPinsAreExemptFromReleaseAge(t *testing.T) {
+	root := repoRoot(t)
+	_, guard := digestRules(t, readRenovateConfig(t))
+
+	for _, version := range []string{"8.8", "8.9", "8.10"} {
+		path := filepath.Join(root, "charts", "camunda-platform-"+version, "values-digest.yaml")
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		for image := range digestImageBlocks(t, contents) {
+			tag := image[strings.LastIndex(image, "@")+1:]
+			guarded := renovateCurrentValueMatches(t, guard.MatchCurrentValue, tag)
+			if strings.Contains(tag, "SNAPSHOT") {
+				assert.False(t, guarded, "%s: snapshot pin %s must not be held by minimumReleaseAge", path, image)
+			} else {
+				assert.True(t, guarded, "%s: release pin %s must keep the minimumReleaseAge guard", path, image)
+			}
 		}
-		assert.Contains(t, rule.MatchUpdateTypes, "digest")
-		assert.Equal(t, "immediate", rule.PRCreation,
-			"moving snapshot digests must not be held by the global not-pending policy")
-		assert.Equal(t, "6 hours", rule.MinimumReleaseAge,
-			"digest updates need time to detect retracted image hashes")
-		return
 	}
-	t.Fatal("camunda-platform-digests package rule not found")
+}
+
+func digestRules(t *testing.T, config RenovateConfig) (group PackageRule, guard PackageRule) {
+	t.Helper()
+	var groups, guards []PackageRule
+	for _, rule := range config.PackageRules {
+		switch {
+		case rule.GroupName == "camunda-platform-digests":
+			groups = append(groups, rule)
+		case rule.MinimumReleaseAge != "" && containsFile(rule.MatchFileNames, "values-digest.yaml"):
+			guards = append(guards, rule)
+		}
+	}
+	require.Len(t, groups, 1, "exactly one camunda-platform-digests group rule expected")
+	require.Len(t, guards, 1, "exactly one minimumReleaseAge rule for values-digest.yaml expected")
+	return groups[0], guards[0]
+}
+
+func renovateCurrentValueMatches(t *testing.T, pattern, value string) bool {
+	t.Helper()
+	negate := strings.HasPrefix(pattern, "!")
+	pattern = strings.TrimPrefix(pattern, "!")
+	require.True(t, strings.HasPrefix(pattern, "/") && strings.HasSuffix(pattern, "/"),
+		"matchCurrentValue %q must be a /regex/ pattern", pattern)
+	re := regexp.MustCompile(strings.TrimSuffix(strings.TrimPrefix(pattern, "/"), "/"))
+	return re.MatchString(value) != negate
 }
 
 func TestDigestRegexDoesNotCrossImageBlocks(t *testing.T) {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #7045.

Renovate ages a digest update against the tag's Docker Hub `tag_last_pushed`, not the digest. A `*-SNAPSHOT` tag re-pushed more often than every six hours never satisfies `minimumReleaseAge: '6 hours'`, so the `camunda-platform-digests` update stays pending and is dropped from the group branch.

### What's in this PR?

- `camunda-platform-digests` group rule no longer carries `minimumReleaseAge`.
- New rule with `matchCurrentValue: '!/SNAPSHOT/'` keeps the six-hour hold for release tags and `latest`, where a moved digest means a re-publish.
- `TestDigestUpdatePolicy` asserts the split; `TestSnapshotDigestPinsAreExemptFromReleaseAge` walks every `values-digest.yaml` and checks SNAPSHOT pins escape the hold while release pins keep it.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
