### PR TITLE
refactor: omit empty init container blocks

### DIFF
--- a/charts/camunda-platform-8.10/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/connectors/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       {{- end }}
     spec:
       imagePullSecrets: {{- include "connectors.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.connectors.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
@@ -34,6 +35,7 @@ spec:
         {{- with .Values.connectors.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: connectors
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}

--- a/charts/camunda-platform-8.10/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "identity.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.identity.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.identity))) | nindent 8 }}
@@ -34,6 +35,7 @@ spec:
         {{- with .Values.identity.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.identity) }}

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -31,6 +31,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "optimize.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.optimize.initContainers .Values.optimize.migration.enabled }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.optimize))) | nindent 8 }}
@@ -147,6 +148,7 @@ spec:
             {{- .Values.optimize.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
         {{- end }}
+          {{- end }}
       containers:
         - name: optimize
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -42,6 +42,7 @@ spec:
       {{- end }}
       imagePullSecrets:
         {{- include "orchestration.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.orchestration))) | nindent 8 }}
@@ -49,6 +50,7 @@ spec:
         {{- with (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: orchestration
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.orchestration) }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -42,6 +42,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "webModeler.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") $hub.restapi.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "webModeler.restapi.image" $)) | nindent 8 }}
@@ -49,6 +50,7 @@ spec:
         {{- with $hub.restapi.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "webModeler.name" . }}-restapi
           image: {{ include "webModeler.restapi.image" . | quote }}

--- a/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
@@ -15,11 +15,16 @@
 package camunda
 
 import (
+	"maps"
+	"strconv"
 	"testing"
 
 	"camunda-platform/test/unit/testhelpers"
 
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type tlsSecretsTest struct {
@@ -253,6 +258,141 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotationWebModeler() {
 			},
 			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *tlsSecretsTest) TestInitContainersRendering() {
+	workloads := []struct {
+		name          string
+		template      string
+		initKey       string
+		containerName string
+		values        map[string]string
+	}{
+		{
+			name: "connectors", template: "templates/connectors/deployment.yaml",
+			initKey: "connectors.initContainers", containerName: "connectors",
+			values: map[string]string{"connectors.enabled": "true"},
+		},
+		{
+			name: "identity", template: "templates/identity/deployment.yaml",
+			initKey: "identity.initContainers", containerName: "camunda-platform",
+		},
+		{
+			name: "orchestration", template: "templates/orchestration/statefulset.yaml",
+			initKey: "orchestration.initContainers", containerName: "orchestration",
+			values: map[string]string{"orchestration.enabled": "true"},
+		},
+		{
+			name: "orchestration-legacy", template: "templates/orchestration/statefulset.yaml",
+			initKey: "orchestration.extraInitContainers", containerName: "orchestration",
+			values: map[string]string{"orchestration.enabled": "true"},
+		},
+		{
+			name: "optimize", template: "templates/optimize/deployment.yaml",
+			initKey: "optimize.initContainers", containerName: "optimize",
+			values: map[string]string{"optimize.enabled": "true"},
+		},
+		{
+			name: "optimize-migration", template: "templates/optimize/deployment.yaml",
+			initKey: "optimize.initContainers", containerName: "optimize",
+			values: map[string]string{"optimize.enabled": "true", "optimize.migration.enabled": "true"},
+		},
+		{
+			name: "restapi", template: "templates/web-modeler/deployment-restapi.yaml",
+			initKey: "camundaHub.restapi.initContainers", containerName: "web-modeler-restapi",
+			values: map[string]string{
+				"camundaHub.enabled":                  "true",
+				"camundaHub.restapi.mail.fromAddress": "test@example.com",
+			},
+		},
+		{
+			name: "restapi-legacy", template: "templates/web-modeler/deployment-restapi.yaml",
+			initKey: "webModeler.restapi.initContainers", containerName: "web-modeler-restapi",
+			values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+			},
+		},
+	}
+
+	var testCases []testhelpers.TestCase
+	for _, workload := range workloads {
+		for _, scenario := range []struct {
+			name     string
+			caBundle bool
+			custom   bool
+		}{
+			{name: "empty"},
+			{name: "ca-only", caBundle: true},
+			{name: "custom-only", custom: true},
+			{name: "ca-and-custom", caBundle: true, custom: true},
+		} {
+			values := map[string]string{
+				"identity.enabled":                          "true",
+				"global.noSecondaryStorage":                 "false",
+				"global.tls.caBundle.secret.existingSecret": "",
+				"optimize.migration.enabled":                "false",
+			}
+			maps.Copy(values, workload.values)
+			var expectedNames []string
+			if scenario.caBundle {
+				values["global.tls.caBundle.secret.existingSecret"] = "test-ca-bundle"
+				expectedNames = append(expectedNames, "ca-bundle-truststore-init")
+			}
+			customContainer := corev1.Container{
+				Name: "custom-" + s.release, Image: "busybox:1.36",
+				Command: []string{"sh", "-c", "echo ready"},
+			}
+			if scenario.custom {
+				values[workload.initKey+"[0].name"] = "custom-{{ .Release.Name }}"
+				values[workload.initKey+"[0].image"] = customContainer.Image
+				for index, command := range customContainer.Command {
+					values[workload.initKey+"[0].command["+strconv.Itoa(index)+"]"] = command
+				}
+				if workload.initKey == "orchestration.initContainers" {
+					values["orchestration.extraInitContainers[0].name"] = "legacy-must-not-render"
+					values["orchestration.extraInitContainers[0].image"] = "busybox:1.36"
+				}
+				expectedNames = append(expectedNames, customContainer.Name)
+			}
+			if values["optimize.migration.enabled"] == "true" {
+				expectedNames = append(expectedNames, "migration")
+			}
+			testCase := testhelpers.TestCase{
+				Name: workload.name + "/" + scenario.name, Template: workload.template, Values: values,
+			}
+			if len(expectedNames) == 0 {
+				testCase.Expected = map[string]string{
+					"spec.template.spec.containers[0].name": workload.containerName,
+				}
+				testCase.Unexpected = []string{"spec.template.spec.initContainers"}
+			} else {
+				testCase.Verifier = func(t *testing.T, output string, err error) {
+					require.NoError(t, err)
+					var resource struct {
+						Spec struct {
+							Template corev1.PodTemplateSpec
+						}
+					}
+					helm.UnmarshalK8SYaml(t, output, &resource)
+					podSpec := resource.Spec.Template.Spec
+					require.NotEmpty(t, podSpec.Containers)
+					require.Equal(t, workload.containerName, podSpec.Containers[0].Name)
+					var actualNames []string
+					for _, container := range podSpec.InitContainers {
+						actualNames = append(actualNames, container.Name)
+					}
+					require.Equal(t, expectedNames, actualNames)
+					if scenario.custom {
+						require.Contains(t, podSpec.InitContainers, customContainer)
+					}
+				}
+			}
+			testCases = append(testCases, testCase)
+		}
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/connectors/golden/deployment.golden.yaml
@@ -40,7 +40,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: connectors
           image: camunda/connectors-bundle:8.10.0-alpha5

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/deployment.golden.yaml
@@ -40,7 +40,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: camunda-platform
           image: camunda/identity:8.10.0-alpha4.2

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/statefulset-rdbms.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/statefulset-rdbms.golden.yaml
@@ -41,7 +41,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: orchestration
           image: camunda/camunda:8.10.0-alpha5

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/statefulset.golden.yaml
@@ -41,7 +41,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: orchestration
           image: camunda/camunda:8.10.0-alpha5

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -41,7 +41,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: web-modeler-restapi
           image: "camunda/hub:8.10.0-alpha3-rc1"

--- a/charts/camunda-platform-8.8/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/connectors/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       {{- end }}
     spec:
       imagePullSecrets: {{- include "connectors.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.connectors.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
@@ -33,6 +34,7 @@ spec:
         {{- with .Values.connectors.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: connectors
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}

--- a/charts/camunda-platform-8.8/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/identity/deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "identity.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.identity.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.identity))) | nindent 8 }}
@@ -34,6 +35,7 @@ spec:
         {{- with .Values.identity.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.identity) }}

--- a/charts/camunda-platform-8.8/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/optimize/deployment.yaml
@@ -30,6 +30,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "optimize.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.optimize.initContainers .Values.optimize.migration.enabled }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.optimize))) | nindent 8 }}
@@ -134,6 +135,7 @@ spec:
             {{- .Values.optimize.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
         {{- end }}
+          {{- end }}
       containers:
         - name: optimize
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}

--- a/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "orchestration.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.orchestration))) | nindent 8 }}
@@ -34,6 +35,7 @@ spec:
         {{- with (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: orchestration-migration-importer
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.orchestration) }}

--- a/charts/camunda-platform-8.8/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/statefulset.yaml
@@ -37,6 +37,7 @@ spec:
       {{- end }}
       imagePullSecrets:
         {{- include "orchestration.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.orchestration))) | nindent 8 }}
@@ -44,6 +45,7 @@ spec:
         {{- with (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: orchestration
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.orchestration) }}

--- a/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "webModeler.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.webModeler.restapi.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "webModeler.restapi.image" $)) | nindent 8 }}
@@ -41,6 +42,7 @@ spec:
         {{- with .Values.webModeler.restapi.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "webModeler.name" . }}-restapi
           image: {{ include "webModeler.restapi.image" . | quote }}

--- a/charts/camunda-platform-8.8/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/tls_secrets_test.go
@@ -15,11 +15,16 @@
 package camunda
 
 import (
+	"maps"
+	"strconv"
 	"testing"
 
 	"camunda-platform/test/unit/testhelpers"
 
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type tlsSecretsTest struct {
@@ -417,6 +422,143 @@ func (s *tlsSecretsTest) TestCaBundleWebModelerWebapp() {
 			},
 		},
 	}
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *tlsSecretsTest) TestInitContainersRendering() {
+	workloads := []struct {
+		name          string
+		template      string
+		initKey       string
+		containerName string
+		values        map[string]string
+	}{
+		{
+			name: "connectors", template: "templates/connectors/deployment.yaml",
+			initKey: "connectors.initContainers", containerName: "connectors",
+			values: map[string]string{"connectors.enabled": "true"},
+		},
+		{
+			name: "identity", template: "templates/identity/deployment.yaml",
+			initKey: "identity.initContainers", containerName: "camunda-platform",
+		},
+		{
+			name: "orchestration", template: "templates/orchestration/statefulset.yaml",
+			initKey: "orchestration.initContainers", containerName: "orchestration",
+			values: map[string]string{"orchestration.enabled": "true"},
+		},
+		{
+			name: "orchestration-legacy", template: "templates/orchestration/statefulset.yaml",
+			initKey: "orchestration.extraInitContainers", containerName: "orchestration",
+			values: map[string]string{"orchestration.enabled": "true"},
+		},
+		{
+			name: "importer", template: "templates/orchestration/importer-deployment.yaml",
+			initKey: "orchestration.initContainers", containerName: "orchestration-migration-importer",
+			values: map[string]string{"orchestration.migration.data.enabled": "true"},
+		},
+		{
+			name: "importer-legacy", template: "templates/orchestration/importer-deployment.yaml",
+			initKey: "orchestration.extraInitContainers", containerName: "orchestration-migration-importer",
+			values: map[string]string{"orchestration.migration.data.enabled": "true"},
+		},
+		{
+			name: "optimize", template: "templates/optimize/deployment.yaml",
+			initKey: "optimize.initContainers", containerName: "optimize",
+			values: map[string]string{"optimize.enabled": "true"},
+		},
+		{
+			name: "optimize-migration", template: "templates/optimize/deployment.yaml",
+			initKey: "optimize.initContainers", containerName: "optimize",
+			values: map[string]string{"optimize.enabled": "true", "optimize.migration.enabled": "true"},
+		},
+		{
+			name: "restapi", template: "templates/web-modeler/deployment-restapi.yaml",
+			initKey: "webModeler.restapi.initContainers", containerName: "web-modeler-restapi",
+			values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+			},
+		},
+	}
+
+	var testCases []testhelpers.TestCase
+	for _, workload := range workloads {
+		for _, scenario := range []struct {
+			name     string
+			caBundle bool
+			custom   bool
+		}{
+			{name: "empty"},
+			{name: "ca-only", caBundle: true},
+			{name: "custom-only", custom: true},
+			{name: "ca-and-custom", caBundle: true, custom: true},
+		} {
+			values := map[string]string{
+				"identity.enabled":                          "true",
+				"global.noSecondaryStorage":                 "false",
+				"global.tls.caBundle.secret.existingSecret": "",
+				"optimize.migration.enabled":                "false",
+			}
+			maps.Copy(values, workload.values)
+			var expectedNames []string
+			if scenario.caBundle {
+				values["global.tls.caBundle.secret.existingSecret"] = "test-ca-bundle"
+				expectedNames = append(expectedNames, "ca-bundle-truststore-init")
+			}
+			customContainer := corev1.Container{
+				Name: "custom-" + s.release, Image: "busybox:1.36",
+				Command: []string{"sh", "-c", "echo ready"},
+			}
+			if scenario.custom {
+				values[workload.initKey+"[0].name"] = "custom-{{ .Release.Name }}"
+				values[workload.initKey+"[0].image"] = customContainer.Image
+				for index, command := range customContainer.Command {
+					values[workload.initKey+"[0].command["+strconv.Itoa(index)+"]"] = command
+				}
+				if workload.initKey == "orchestration.initContainers" {
+					values["orchestration.extraInitContainers[0].name"] = "legacy-must-not-render"
+					values["orchestration.extraInitContainers[0].image"] = "busybox:1.36"
+				}
+				expectedNames = append(expectedNames, customContainer.Name)
+			}
+			if values["optimize.migration.enabled"] == "true" {
+				expectedNames = append(expectedNames, "migration")
+			}
+			testCase := testhelpers.TestCase{
+				Name: workload.name + "/" + scenario.name, Template: workload.template, Values: values,
+			}
+			if len(expectedNames) == 0 {
+				testCase.Expected = map[string]string{
+					"spec.template.spec.containers[0].name": workload.containerName,
+				}
+				testCase.Unexpected = []string{"spec.template.spec.initContainers"}
+			} else {
+				testCase.Verifier = func(t *testing.T, output string, err error) {
+					require.NoError(t, err)
+					var resource struct {
+						Spec struct {
+							Template corev1.PodTemplateSpec
+						}
+					}
+					helm.UnmarshalK8SYaml(t, output, &resource)
+					podSpec := resource.Spec.Template.Spec
+					require.NotEmpty(t, podSpec.Containers)
+					require.Equal(t, workload.containerName, podSpec.Containers[0].Name)
+					var actualNames []string
+					for _, container := range podSpec.InitContainers {
+						actualNames = append(actualNames, container.Name)
+					}
+					require.Equal(t, expectedNames, actualNames)
+					if scenario.custom {
+						require.Contains(t, podSpec.InitContainers, customContainer)
+					}
+				}
+			}
+			testCases = append(testCases, testCase)
+		}
+	}
+
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 

--- a/charts/camunda-platform-8.8/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/connectors/golden/deployment.golden.yaml
@@ -40,7 +40,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: connectors
           image: camunda/connectors-bundle:8.8.19

--- a/charts/camunda-platform-8.8/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/identity/golden/deployment.golden.yaml
@@ -40,7 +40,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: camunda-platform
           image: camunda/identity:8.8.17

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/importer-deployment.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/importer-deployment.golden.yaml
@@ -39,7 +39,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: orchestration-migration-importer
           image: camunda/camunda:8.8.37

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/statefulset.golden.yaml
@@ -41,7 +41,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: orchestration
           image: camunda/camunda:8.8.37

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -37,7 +37,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: web-modeler-restapi
           image: "camunda/web-modeler-restapi:8.8.19"

--- a/charts/camunda-platform-8.9/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.9/templates/connectors/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       {{- end }}
     spec:
       imagePullSecrets: {{- include "connectors.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.connectors.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
@@ -33,6 +34,7 @@ spec:
         {{- with .Values.connectors.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: connectors
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}

--- a/charts/camunda-platform-8.9/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-8.9/templates/identity/deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "identity.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.identity.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.identity))) | nindent 8 }}
@@ -34,6 +35,7 @@ spec:
         {{- with .Values.identity.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.identity) }}

--- a/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
@@ -31,6 +31,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "optimize.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.optimize.initContainers .Values.optimize.migration.enabled }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.optimize))) | nindent 8 }}
@@ -147,6 +148,7 @@ spec:
             {{- .Values.optimize.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
         {{- end }}
+          {{- end }}
       containers:
         - name: optimize
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}

--- a/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
       {{- end }}
       imagePullSecrets:
         {{- include "orchestration.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.orchestration))) | nindent 8 }}
@@ -45,6 +46,7 @@ spec:
         {{- with (coalesce .Values.orchestration.initContainers .Values.orchestration.extraInitContainers) }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: orchestration
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.orchestration) }}

--- a/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "webModeler.imagePullSecrets" . | nindent 8 }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.webModeler.restapi.initContainers }}
       initContainers:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "webModeler.restapi.image" $)) | nindent 8 }}
@@ -41,6 +42,7 @@ spec:
         {{- with .Values.webModeler.restapi.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "webModeler.name" . }}-restapi
           image: {{ include "webModeler.restapi.image" . | quote }}

--- a/charts/camunda-platform-8.9/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/tls_secrets_test.go
@@ -15,10 +15,15 @@
 package camunda
 
 import (
+	"maps"
+	"strconv"
 	"testing"
 
 	"camunda-platform/test/unit/testhelpers"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type tlsSecretsTest struct {
@@ -960,6 +965,133 @@ func (s *tlsSecretsTest) TestCaBundleOptimize() {
 			},
 		},
 	}
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *tlsSecretsTest) TestInitContainersRendering() {
+	workloads := []struct {
+		name          string
+		template      string
+		initKey       string
+		containerName string
+		values        map[string]string
+	}{
+		{
+			name: "connectors", template: "templates/connectors/deployment.yaml",
+			initKey: "connectors.initContainers", containerName: "connectors",
+			values: map[string]string{"connectors.enabled": "true"},
+		},
+		{
+			name: "identity", template: "templates/identity/deployment.yaml",
+			initKey: "identity.initContainers", containerName: "camunda-platform",
+		},
+		{
+			name: "orchestration", template: "templates/orchestration/statefulset.yaml",
+			initKey: "orchestration.initContainers", containerName: "orchestration",
+			values: map[string]string{"orchestration.enabled": "true"},
+		},
+		{
+			name: "orchestration-legacy", template: "templates/orchestration/statefulset.yaml",
+			initKey: "orchestration.extraInitContainers", containerName: "orchestration",
+			values: map[string]string{"orchestration.enabled": "true"},
+		},
+		{
+			name: "optimize", template: "templates/optimize/deployment.yaml",
+			initKey: "optimize.initContainers", containerName: "optimize",
+			values: map[string]string{"optimize.enabled": "true"},
+		},
+		{
+			name: "optimize-migration", template: "templates/optimize/deployment.yaml",
+			initKey: "optimize.initContainers", containerName: "optimize",
+			values: map[string]string{"optimize.enabled": "true", "optimize.migration.enabled": "true"},
+		},
+		{
+			name: "restapi", template: "templates/web-modeler/deployment-restapi.yaml",
+			initKey: "webModeler.restapi.initContainers", containerName: "web-modeler-restapi",
+			values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+			},
+		},
+	}
+
+	var testCases []testhelpers.TestCase
+	for _, workload := range workloads {
+		for _, scenario := range []struct {
+			name     string
+			caBundle bool
+			custom   bool
+		}{
+			{name: "empty"},
+			{name: "ca-only", caBundle: true},
+			{name: "custom-only", custom: true},
+			{name: "ca-and-custom", caBundle: true, custom: true},
+		} {
+			values := map[string]string{
+				"identity.enabled":                          "true",
+				"global.noSecondaryStorage":                 "false",
+				"global.tls.caBundle.secret.existingSecret": "",
+				"optimize.migration.enabled":                "false",
+			}
+			maps.Copy(values, workload.values)
+			var expectedNames []string
+			if scenario.caBundle {
+				values["global.tls.caBundle.secret.existingSecret"] = "test-ca-bundle"
+				expectedNames = append(expectedNames, "ca-bundle-truststore-init")
+			}
+			customContainer := corev1.Container{
+				Name: "custom-" + s.release, Image: "busybox:1.36",
+				Command: []string{"sh", "-c", "echo ready"},
+			}
+			if scenario.custom {
+				values[workload.initKey+"[0].name"] = "custom-{{ .Release.Name }}"
+				values[workload.initKey+"[0].image"] = customContainer.Image
+				for index, command := range customContainer.Command {
+					values[workload.initKey+"[0].command["+strconv.Itoa(index)+"]"] = command
+				}
+				if workload.initKey == "orchestration.initContainers" {
+					values["orchestration.extraInitContainers[0].name"] = "legacy-must-not-render"
+					values["orchestration.extraInitContainers[0].image"] = "busybox:1.36"
+				}
+				expectedNames = append(expectedNames, customContainer.Name)
+			}
+			if values["optimize.migration.enabled"] == "true" {
+				expectedNames = append(expectedNames, "migration")
+			}
+			testCase := testhelpers.TestCase{
+				Name: workload.name + "/" + scenario.name, Template: workload.template, Values: values,
+			}
+			if len(expectedNames) == 0 {
+				testCase.Expected = map[string]string{
+					"spec.template.spec.containers[0].name": workload.containerName,
+				}
+				testCase.Unexpected = []string{"spec.template.spec.initContainers"}
+			} else {
+				testCase.Verifier = func(t *testing.T, output string, err error) {
+					require.NoError(t, err)
+					var resource struct {
+						Spec struct {
+							Template corev1.PodTemplateSpec
+						}
+					}
+					helm.UnmarshalK8SYaml(t, output, &resource)
+					podSpec := resource.Spec.Template.Spec
+					require.NotEmpty(t, podSpec.Containers)
+					require.Equal(t, workload.containerName, podSpec.Containers[0].Name)
+					var actualNames []string
+					for _, container := range podSpec.InitContainers {
+						actualNames = append(actualNames, container.Name)
+					}
+					require.Equal(t, expectedNames, actualNames)
+					if scenario.custom {
+						require.Contains(t, podSpec.InitContainers, customContainer)
+					}
+				}
+			}
+			testCases = append(testCases, testCase)
+		}
+	}
+
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 

--- a/charts/camunda-platform-8.9/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/connectors/golden/deployment.golden.yaml
@@ -40,7 +40,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: connectors
           image: camunda/connectors-bundle:8.9.10

--- a/charts/camunda-platform-8.9/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/identity/golden/deployment.golden.yaml
@@ -40,7 +40,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: camunda-platform
           image: camunda/identity:8.9.9

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/statefulset-rdbms.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/statefulset-rdbms.golden.yaml
@@ -41,7 +41,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: orchestration
           image: camunda/camunda:8.9.19

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/statefulset.golden.yaml
@@ -41,7 +41,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: orchestration
           image: camunda/camunda:8.9.19

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -37,7 +37,6 @@ spec:
     spec:
       imagePullSecrets:
         []
-      initContainers:
       containers:
         - name: web-modeler-restapi
           image: "camunda/web-modeler-restapi:8.9.8"


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6377.

CA-bundle-wired workloads render a bare `initContainers:` key when no init containers are configured. Kubernetes accepts the resulting null, but the key should be omitted in that case.

### What's in this PR?

- Guard the complete init-container block in 16 templates across 8.8, 8.9, and 8.10, including the 8.8 migration importer and Optimize with migration disabled.
- Preserve CA initialization, custom-container contents and ordering, orchestration's `extraInitContainers` fallback and modern-key precedence, Optimize migration-only configurations, and 8.10 Camunda Hub/Web Modeler value compatibility.
- Add 96 rendering regression cases in the existing TLS suites. Empty cases assert structural absence with a positive main-container anchor; populated cases verify exact init-container names/order and custom-container contents.
- Regenerate goldens. The snapshot diff is limited to 15 bare-key removals; existing empty-list rendering and populated snapshots remain unchanged.

No values API, schema, image, or dependency changes.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
