### PR TITLE
test: place keycloak companion postgresql on the scenario pool

### DIFF
--- a/charts/camunda-platform-8.10/test/unit/companion/golden/internal-keycloak-26-postgresql-statefulset-arm.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/companion/golden/internal-keycloak-26-postgresql-statefulset-arm.golden.yaml
@@ -1,0 +1,108 @@
+---
+# Source: internal-keycloak/templates/postgresql-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda-platform-test-internal-keycloak-postgresql
+  labels:
+    app.kubernetes.io/name: internal-keycloak
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/version: "16-alpine"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  serviceName: camunda-platform-test-internal-keycloak-postgresql
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: internal-keycloak
+      app.kubernetes.io/instance: camunda-platform-test
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: internal-keycloak
+        app.kubernetes.io/instance: camunda-platform-test
+        app.kubernetes.io/component: postgresql
+        camunda.io/controller: statefulset
+    spec:
+      nodeSelector:
+        workload: arm-processor
+      tolerations:
+        - effect: NoSchedule
+          key: workload
+          operator: Equal
+          value: arm-processor
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
+      containers:
+        - name: postgresql
+          image: docker.io/postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: "keycloak"
+            - name: POSTGRES_USER
+              value: "keycloak"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-platform-test-internal-keycloak-postgresql
+                  key: postgresql-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - "keycloak"
+                - -d
+                - "keycloak"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - "keycloak"
+                - -d
+                - "keycloak"
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: internal-keycloak
+          app.kubernetes.io/instance: camunda-platform-test
+          app.kubernetes.io/component: postgresql
+          app.kubernetes.io/version: "16-alpine"
+          app.kubernetes.io/managed-by: Helm
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: "hyperdisk-balanced"
+        resources:
+          requests:
+            storage: "4Gi"

--- a/charts/camunda-platform-8.10/test/unit/companion/goldenfiles_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/goldenfiles_test.go
@@ -52,3 +52,31 @@ func TestGoldenDefaultsTemplateCompanionKeycloakPostgresql(t *testing.T) {
 		Templates:      []string{"templates/postgresql-statefulset.yaml"},
 	})
 }
+
+func TestGoldenARMSchedulingTemplateCompanionKeycloakPostgresql(test *testing.T) {
+	test.Parallel()
+
+	chartPath, err := filepath.Abs("../../../../internal-keycloak-26")
+	require.NoError(test, err)
+
+	suite.Run(test, &utils.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform",
+		GoldenFileName: "internal-keycloak-26-postgresql-statefulset-arm",
+		Templates:      []string{"templates/postgresql-statefulset.yaml"},
+		SetValues: map[string]string{
+			"nodeSelector.workload":               "arm-processor",
+			"tolerations[0].key":                  "workload",
+			"tolerations[0].operator":             "Equal",
+			"tolerations[0].value":                "arm-processor",
+			"tolerations[0].effect":               "NoSchedule",
+			"tolerations[1].key":                  "kubernetes.io/arch",
+			"tolerations[1].operator":             "Equal",
+			"tolerations[1].value":                "arm64",
+			"tolerations[1].effect":               "NoSchedule",
+			"postgresql.storage.storageClassName": "hyperdisk-balanced",
+			"postgresql.storage.size":             "4Gi",
+		},
+	})
+}

--- a/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
@@ -107,3 +107,92 @@ func (s *KeycloakPostgresqlStatefulSetTest) TestStorageDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (suiteTest *KeycloakPostgresqlStatefulSetTest) TestSchedulingDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestSchedulingAbsentByDefault",
+			Verifier: func(test *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(test, output, err)
+
+				require.NotEmpty(test, statefulSet.Spec.Template.Spec.Containers)
+				require.Nil(test, statefulSet.Spec.Template.Spec.NodeSelector)
+				require.Nil(test, statefulSet.Spec.Template.Spec.Tolerations)
+			},
+		},
+		{
+			Name:   "TestNodeSelectorWithoutTolerations",
+			Values: map[string]string{"nodeSelector.workload": "distroci"},
+			Verifier: func(test *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(test, output, err)
+
+				require.Equal(test, map[string]string{"workload": "distroci"}, statefulSet.Spec.Template.Spec.NodeSelector)
+				require.Nil(test, statefulSet.Spec.Template.Spec.Tolerations)
+			},
+		},
+		{
+			Name: "TestTolerationsWithoutNodeSelector",
+			Values: map[string]string{
+				"tolerations[0].key":      "workload",
+				"tolerations[0].operator": "Exists",
+			},
+			Verifier: func(test *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(test, output, err)
+
+				require.Nil(test, statefulSet.Spec.Template.Spec.NodeSelector)
+				require.Equal(test, []corev1.Toleration{{Key: "workload", Operator: corev1.TolerationOpExists}}, statefulSet.Spec.Template.Spec.Tolerations)
+			},
+		},
+	}
+
+	for _, workload := range []string{"distroci", "qa-workloads", "arm-processor"} {
+		values := map[string]string{
+			"nodeSelector.workload":   workload,
+			"tolerations[0].effect":   "NoSchedule",
+			"tolerations[0].key":      "workload",
+			"tolerations[0].operator": "Equal",
+			"tolerations[0].value":    workload,
+		}
+		tolerations := []corev1.Toleration{{
+			Key:      "workload",
+			Operator: corev1.TolerationOpEqual,
+			Value:    workload,
+			Effect:   corev1.TaintEffectNoSchedule,
+		}}
+		var storageClass *string
+		if workload == "arm-processor" {
+			values["tolerations[1].key"] = "kubernetes.io/arch"
+			values["tolerations[1].operator"] = "Equal"
+			values["tolerations[1].value"] = "arm64"
+			values["tolerations[1].effect"] = "NoSchedule"
+			values["postgresql.storage.storageClassName"] = "hyperdisk-balanced"
+			values["postgresql.storage.size"] = "4Gi"
+			tolerations = append(tolerations, corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			})
+			storageClassName := "hyperdisk-balanced"
+			storageClass = &storageClassName
+		}
+
+		testCases = append(testCases, testhelpers.TestCase{
+			Name:   "TestSchedulingInherits_" + workload,
+			Values: values,
+			Verifier: func(test *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(test, output, err)
+
+				require.Equal(test, map[string]string{"workload": workload}, statefulSet.Spec.Template.Spec.NodeSelector)
+				require.Equal(test, tolerations, statefulSet.Spec.Template.Spec.Tolerations)
+				require.Len(test, statefulSet.Spec.VolumeClaimTemplates, 1)
+				require.Equal(test, storageClass, statefulSet.Spec.VolumeClaimTemplates[0].Spec.StorageClassName)
+				if workload == "arm-processor" {
+					require.Equal(test, "4Gi", statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().String())
+				}
+			},
+		})
+	}
+
+	testhelpers.RunTestCasesE(suiteTest.T(), suiteTest.chartPath, suiteTest.release, suiteTest.namespace, suiteTest.templates, testCases)
+}

--- a/charts/internal-keycloak-26/templates/postgresql-statefulset.yaml
+++ b/charts/internal-keycloak-26/templates/postgresql-statefulset.yaml
@@ -23,6 +23,14 @@ spec:
         - name: {{ . }}
         {{- end }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgresql
           image: {{ include "keycloak.postgresql.image" . }}

--- a/charts/internal-keycloak-26/values.yaml
+++ b/charts/internal-keycloak-26/values.yaml
@@ -87,10 +87,10 @@ replicas: 1
 ## @param podAnnotations Additional annotations for Keycloak pods.
 podAnnotations: {}
 
-## @param nodeSelector Node selector for Keycloak pods.
+## @param nodeSelector can be used to select nodes for Keycloak and bundled PostgreSQL pods.
 nodeSelector: {}
 
-## @param tolerations Tolerations for Keycloak pods.
+## @param tolerations can be used to tolerate node taints for Keycloak and bundled PostgreSQL pods.
 tolerations: []
 
 ## Bundled PostgreSQL for Keycloak's database.

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"scripts/camunda-core/pkg/helm"
 	"scripts/camunda-core/pkg/logging"
@@ -28,6 +29,8 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Package-level function variables for helm operations. These default to the
@@ -255,15 +258,41 @@ func formatArgs(args []string) string {
 var companionRepoMu sync.Mutex
 
 // companionStorageClassPaths maps a companion release name to the Helm value
-// that sets the storage class on its claim template. Only companions whose pods
-// follow CompanionNodeSelector onto the infra pool belong here: the pool's
-// machine type constrains which disk types can attach, so their PVCs must use a
-// compatible class. The keycloak companion's postgresql StatefulSet is
-// deliberately absent — it declares no nodeSelector, so it stays on the default
-// pool where the cluster default class works.
+// that sets the storage class on its claim template.
 var companionStorageClassPaths = map[string]string{
 	"elasticsearch": "volumeClaimTemplate.storageClassName",
+	"keycloak":      "postgresql.storage.storageClassName",
 	"postgresql":    "persistence.storageClass",
+}
+
+func keycloakPostgresqlStorageMinimum(valuesFile string) (string, error) {
+	var values struct {
+		Postgresql struct {
+			Storage struct {
+				Size string `yaml:"size"`
+			} `yaml:"storage"`
+		} `yaml:"postgresql"`
+	}
+	if valuesFile != "" {
+		content, err := os.ReadFile(valuesFile)
+		if err != nil {
+			return "", fmt.Errorf("read keycloak companion values: %w", err)
+		}
+		if err := yaml.Unmarshal(content, &values); err != nil {
+			return "", fmt.Errorf("parse keycloak companion values: %w", err)
+		}
+	}
+	minimum := resource.MustParse("4Gi")
+	if values.Postgresql.Storage.Size != "" {
+		requested, err := resource.ParseQuantity(values.Postgresql.Storage.Size)
+		if err != nil {
+			return "", fmt.Errorf("parse keycloak postgresql storage size: %w", err)
+		}
+		if requested.Cmp(minimum) >= 0 {
+			return "", nil
+		}
+	}
+	return minimum.String(), nil
 }
 
 // deployCompanionCharts deploys all configured companion charts concurrently,
@@ -361,6 +390,15 @@ func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.
 	}
 	if path, ok := companionStorageClassPaths[cc.ReleaseName]; ok && o.CompanionStorageClass != "" {
 		args = append(args, "--set", path+"="+o.CompanionStorageClass)
+	}
+	if cc.ReleaseName == "keycloak" && o.CompanionStorageClass == "hyperdisk-balanced" {
+		minimum, err := keycloakPostgresqlStorageMinimum(cc.ValuesFile)
+		if err != nil {
+			return &HelmError{Reason: "resolve keycloak postgresql storage minimum", Cause: err}
+		}
+		if minimum != "" {
+			args = append(args, "--set", "postgresql.storage.size="+minimum)
+		}
 	}
 
 	// Companion charts always pass --wait (see the args above), independently of o.Wait.

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"scripts/deploy-camunda/pkg/types"
 	"strings"
 	"sync/atomic"
@@ -135,16 +137,17 @@ func stubHelm(
 
 func TestDeployCompanionChart(t *testing.T) {
 	tests := []struct {
-		name        string
-		cc          types.CompanionChart
-		opts        types.Options
-		runErr      error
-		repoAddErr  error
-		repoUpdErr  error
-		wantErr     string   // substring expected in error message; empty = no error
-		wantArgs    []string // substrings expected in the helm run args
-		notWantArgs []string // substrings that must NOT appear in helm run args
-		wantRepoAdd bool     // expect helmRepoAdd to be called
+		name          string
+		cc            types.CompanionChart
+		opts          types.Options
+		runErr        error
+		repoAddErr    error
+		repoUpdErr    error
+		valuesContent string
+		wantErr       string   // substring expected in error message; empty = no error
+		wantArgs      []string // substrings expected in the helm run args
+		notWantArgs   []string // substrings that must NOT appear in helm run args
+		wantRepoAdd   bool     // expect helmRepoAdd to be called
 	}{
 		{
 			name: "remote chart with version and repo registration",
@@ -316,7 +319,7 @@ func TestDeployCompanionChart(t *testing.T) {
 			wantArgs: []string{"--set", "persistence.storageClass=hyperdisk-balanced"},
 		},
 		{
-			name: "keycloak companion is excluded from the storage class override",
+			name: "keycloak postgresql storage class override",
 			cc: types.CompanionChart{
 				ChartRef:    "internal-keycloak-26",
 				ReleaseName: "keycloak",
@@ -325,7 +328,60 @@ func TestDeployCompanionChart(t *testing.T) {
 				Namespace:             "ns",
 				CompanionStorageClass: "hyperdisk-balanced",
 			},
-			notWantArgs: []string{"hyperdisk-balanced"},
+			wantArgs: []string{"--set", "postgresql.storage.storageClassName=hyperdisk-balanced", "postgresql.storage.size=4Gi"},
+		},
+		{
+			name:          "keycloak raises an undersized hyperdisk volume",
+			cc:            types.CompanionChart{ChartRef: "internal-keycloak-26", ReleaseName: "keycloak"},
+			opts:          types.Options{Namespace: "ns", CompanionStorageClass: "hyperdisk-balanced"},
+			valuesContent: "postgresql:\n  storage:\n    size: 2Gi\n",
+			wantArgs:      []string{"postgresql.storage.size=4Gi"},
+		},
+		{
+			name:          "keycloak preserves a larger hyperdisk volume",
+			cc:            types.CompanionChart{ChartRef: "internal-keycloak-26", ReleaseName: "keycloak"},
+			opts:          types.Options{Namespace: "ns", CompanionStorageClass: "hyperdisk-balanced"},
+			valuesContent: "postgresql:\n  storage:\n    size: 8Gi\n",
+			wantArgs:      []string{"postgresql.storage.storageClassName=hyperdisk-balanced"},
+			notWantArgs:   []string{"postgresql.storage.size="},
+		},
+		{
+			name:          "keycloak preserves a minimum-sized hyperdisk volume",
+			cc:            types.CompanionChart{ChartRef: "internal-keycloak-26", ReleaseName: "keycloak"},
+			opts:          types.Options{Namespace: "ns", CompanionStorageClass: "hyperdisk-balanced"},
+			valuesContent: "postgresql:\n  storage:\n    size: 4096Mi\n",
+			notWantArgs:   []string{"postgresql.storage.size="},
+		},
+		{
+			name:          "keycloak rejects an invalid hyperdisk storage quantity",
+			cc:            types.CompanionChart{ChartRef: "internal-keycloak-26", ReleaseName: "keycloak"},
+			opts:          types.Options{Namespace: "ns", CompanionStorageClass: "hyperdisk-balanced"},
+			valuesContent: "postgresql:\n  storage:\n    size: invalid\n",
+			wantErr:       "parse keycloak postgresql storage size",
+		},
+		{
+			name:    "keycloak reports unreadable storage values",
+			cc:      types.CompanionChart{ChartRef: "internal-keycloak-26", ReleaseName: "keycloak", ValuesFile: "/nonexistent/6833-keycloak-values.yaml"},
+			opts:    types.Options{Namespace: "ns", CompanionStorageClass: "hyperdisk-balanced"},
+			wantErr: "read keycloak companion values",
+		},
+		{
+			name:          "keycloak reports malformed storage values",
+			cc:            types.CompanionChart{ChartRef: "internal-keycloak-26", ReleaseName: "keycloak"},
+			opts:          types.Options{Namespace: "ns", CompanionStorageClass: "hyperdisk-balanced"},
+			valuesContent: "postgresql: [",
+			wantErr:       "parse keycloak companion values",
+		},
+		{
+			name: "keycloak preserves the configured storage class without an override",
+			cc: types.CompanionChart{
+				ChartRef:    "internal-keycloak-26",
+				ReleaseName: "keycloak",
+				ValuesFile:  "/tmp/keycloak-values.yaml",
+			},
+			opts:        types.Options{Namespace: "ns"},
+			wantArgs:    []string{"-f", "/tmp/keycloak-values.yaml"},
+			notWantArgs: []string{"--set", "storageClassName"},
 		},
 		{
 			name: "unmarshalable tolerations value propagates as HelmError",
@@ -344,6 +400,12 @@ func TestDeployCompanionChart(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.valuesContent != "" {
+				tt.cc.ValuesFile = filepath.Join(t.TempDir(), "values.yaml")
+				if err := os.WriteFile(tt.cc.ValuesFile, []byte(tt.valuesContent), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
 			var capturedArgs []string
 			repoAddCalled := false
 


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6833.

`deploy-camunda` derives top-level companion scheduling from the scenario infrastructure, but the internal Keycloak chart's PostgreSQL StatefulSet does not consume those values. This leaves the database outside the selected pool.

GKE events on 2026-08-31 in `camunda-id--intg-8-10-gke-hublu-1c2a08-upgm` show PostgreSQL triggering default-pool scale-up from 3 to 4 nodes, scheduler rejection due to insufficient CPU on untainted nodes, and autoscaler rejection of both `distroci` pools due to untolerated taints. It took approximately 50 seconds from creation to scheduling while Keycloak was waiting for PostgreSQL. This establishes a placement-related delay, not a measured end-to-end speedup or proof that this change prevents CI failures.

### What's in this PR?

- Render the existing release-level `nodeSelector` and `tolerations` on bundled PostgreSQL as well as Keycloak. Empty defaults still render no placement fields; no new values keys or pool-specific companion variants are introduced.
- Extend the existing companion storage override to Keycloak's PostgreSQL. For `hyperdisk-balanced`, apply a 4 GiB minimum without shrinking larger explicitly requested volumes. GKE rejects the chart's 2 GiB default for this disk type. Non-ARM storage defaults remain unchanged.
- Add structural positive/negative scheduling tests, ARM toleration/storage coverage, installer boundary/error tests, and a generated ARM golden. Existing default goldens remain unchanged.
- Keep production Camunda templates, scenario definitions, QA fixtures, and team-distribution IaC untouched.

Validation:

- `make go.update-golden-only chartPath=charts/camunda-platform-8.10`
- `make go.test chartPath=charts/camunda-platform-8.10` (full chart suite and cross-version registry checks)
- `go test ./pkg/deployer ./deploy -count=1` from `scripts/deploy-camunda`
- `make go.fmt`, `make go.addlicense-check`, direct license checks for touched Go tooling, and `make helm.lint chartPath=charts/internal-keycloak-26`
- Isolated GKE companion upgrade from the pre-fix chart: both pods Ready on `distroci` after upgrade; PostgreSQL moved from the default pool; original PVC UID and a seeded database row were preserved.
- Isolated fresh ARM companion install: both pods Ready on `arm-processor`, with a bound 4 GiB `hyperdisk-balanced` PVC.

Compatibility and validation scope:

- The 8.10 ARM scenario is install-only. Existing off-pool ARM companion releases require an explicit data-preserving migration or recreation before adopting a different PVC storage class; this PR does not delete or migrate existing volumes automatically.
- Live verification covered isolated companion releases on GKE, not the complete `deploy-camunda matrix run` workflow or QA/EKS deployments.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?