### PR TITLE
ci: run the full playwright e2e suite for the 8.9 hub cell

### DIFF
--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -761,6 +761,7 @@ integration:
             gke: distroci
           identity: keycloak
           persistence: elasticsearch
+          e2e-full-suite: true
     nightly:
       scenario: []
   flows:

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install.yaml
@@ -8,3 +8,4 @@ platforms:
   - gke
 infra-type:
   gke: distroci
+e2e-full-suite: true


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to #6841 and to camunda/camunda-hub#28404. Related:
[team-test-automation#78](https://github.com/camunda/team-test-automation/issues/78).

camunda-hub's `main` branch is moving to the `alwaysgreen` scenario in
camunda/camunda-hub#28404, which gives its Helm gate the non-blocking full-suite leg. Its
`self-managed/8.9` branch still calls `test-integration-template.yaml` with
`scenario: keycloak-original` / `shortname: kcor`.

Unlike 8.10, `kcor` **does** exist in the 8.9 registry, so it resolves exactly — one install, no
fallback. The only gap is that the scenario declares no full suite, so that gate has only ever run
`smoke-tests.spec.ts`.

That is the coverage gap camunda-hub#28259 slipped through on `main`: it renamed the Play overlay's
`data-test` attribute and merged green, then broke `play.spec.ts` in the nightlies.
`play.spec.ts` is in the `full-suite` project, not in smoke.

### What's in this PR?

One line on the 8.9 scenario that camunda-hub's 8.9 branch resolves to:

```yaml
# charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install.yaml
e2e-full-suite: true
```

plus the regenerated `registry-snapshot.yaml`.

This is the per-scenario opt-in documented in #6841 — nothing changes in camunda-hub, which already
sends `shortname: kcor` and pins `camunda-helm-git-ref: main`, so it takes effect on the next gate
run with no release-branch PR.

The full leg stays **non-blocking** (`blocking: false` by default), consistent with `alwaysgreen` and
the connectors caller. Note that a `continue-on-error` leg still reports `conclusion: failure` as a
check run, so it must not be added to a branch ruleset's required checks — promoting it is a
deliberate `e2e-full-suite-blocking: true` change, not a ruleset edit.

**Why here rather than in camunda-hub:** switching `self-managed/8.9`'s workflow to `alwaysgreen`
would also move that maintenance branch's gate onto the `alwaysgreen` GKE nodepool, changing cost
attribution. This keeps 8.9 on `distroci` and only adds the leg. If uniformity across branches is
preferred instead, say so and I will send the hub-side change.

#### Verification

Against this branch, via `deploy-camunda ci e2e-matrix`:

| | before | after |
|---|---|---|
| 8.9 legs (`--shortname kcor --scenario keycloak-original`) | `[{smoke, blocking}]` | `[{smoke, blocking}, {full, non-blocking}]` |
| 8.9 tier-1 generated matrix | 4 entries | 4 entries |
| 8.9 tier-2 generated matrix | 16 entries | 16 entries |

The generated matrix is unaffected because this scenario is `enabled: false` — external-caller-only,
like `alwaysgreen`.

`go test ./...` in `scripts/deploy-camunda` — all packages pass, including the registry validator and
`TestRegistryGolden`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
