### PR TITLE
test(8.10): add a physicaltenants CI scenario with one Optimize per tenant

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -2074,6 +2074,75 @@ integration:
                 optimize-context-path: /optimize-orchb
             shared-storage: elasticsearch
             shared-storage-service: elasticsearch-master
+        - name: physicaltenants
+          enabled: true
+          shortname: ptnt
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          skip-e2e: true
+          post-deploy:
+            script: post-deploy-physical-tenant-exporters.sh
+            description: |
+              Asserts that every Physical Tenant, including default, opened the legacy
+              Zeebe exporter and is exporting. Fails if any tenant fell back to a
+              BlockingExporter or its exported position is stuck at -1, and fails if fewer
+              than two tenants report partitions. Stands in for the per-tenant Optimize
+              coverage the e2e suite cannot express yet, because Optimize reads the legacy
+              exporter and its records are the only thing a per-tenant Optimize can import.
+          topology:
+            name: hub-1orch-2tenants
+            releases:
+              - role: hub
+                namespace-suffix: hub
+                identity: keycloak
+                features:
+                  - multinamespace-reset-clients
+                  - physicaltenants-hub
+                dependencies:
+                  - keycloak-fixed-issuer
+                  - postgresql
+                  - elasticsearch
+              - role: orchestration
+                namespace-suffix: orcha
+                depends-on: hub
+                identity: keycloak-external
+                persistence: elasticsearch-external
+                features:
+                  - physicaltenants-orchestration
+                env:
+                  ORCH_CONNECTORS_CLIENT_ID: connectors-orcha
+                  ORCH_OPTIMIZE_AUDIENCE: optimize-orcha-api
+                  ORCH_OPTIMIZE_CLIENT_ID: optimize-orcha-ta
+                  ORCH_ORCHESTRATION_AUDIENCE: orchestration-orcha-api
+                  ORCH_ORCHESTRATION_CLIENT_ID: orchestration-orcha
+                modeler-cluster-id: orcha
+                modeler-cluster-name: Orchestration A
+              - role: optimize
+                namespace-suffix: optta
+                depends-on: hub
+                identity: keycloak-external-optimize
+                persistence: elasticsearch-external
+                features:
+                  - physicaltenants-optimize-ta
+                serves: orcha
+                optimize-context-path: /optimize-orcha-ta
+              - role: optimize
+                namespace-suffix: opttb
+                depends-on: hub
+                identity: keycloak-external-optimize
+                persistence: elasticsearch-external
+                features:
+                  - physicaltenants-optimize-tb
+                serves: orcha
+                optimize-context-path: /optimize-orcha-tb
+            shared-storage: elasticsearch
+            shared-storage-service: elasticsearch-master
     nightly:
       scenario: []
   flows:

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -2090,11 +2090,14 @@ integration:
             script: post-deploy-physical-tenant-exporters.sh
             description: |
               Asserts that every Physical Tenant, including default, opened the legacy
-              Zeebe exporter and is exporting. Fails if any tenant fell back to a
-              BlockingExporter or its exported position is stuck at -1, and fails if fewer
-              than two tenants report partitions. Stands in for the per-tenant Optimize
-              coverage the e2e suite cannot express yet, because Optimize reads the legacy
-              exporter and its records are the only thing a per-tenant Optimize can import.
+              Zeebe exporter and is exporting. Requires the reported tenant set to be
+              exactly default, tenanta and tenantb - the set this scenario declares - so a
+              tenant that never registered fails the hook rather than going unnoticed.
+              Each of them must report at least one partition, and fails if any tenant fell
+              back to a BlockingExporter or its exported position is stuck at -1. Stands in
+              for the per-tenant Optimize coverage the e2e suite cannot express yet, because
+              Optimize reads the legacy exporter and its records are the only thing a
+              per-tenant Optimize can import.
           topology:
             name: hub-1orch-2tenants
             releases:

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/keycloak-fixed-issuer.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/keycloak-fixed-issuer.yaml
@@ -1,0 +1,5 @@
+chart: charts/internal-keycloak-26
+release-name: keycloak
+values-file: test/integration/companion-values/keycloak-fixed-issuer.yaml
+env-vars:
+  - CAMUNDA_HOSTNAME

--- a/charts/camunda-platform-8.10/test/ci/registry/hooks/physicaltenants-exporters.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/hooks/physicaltenants-exporters.yaml
@@ -1,0 +1,8 @@
+script: post-deploy-physical-tenant-exporters.sh
+description: |
+  Asserts that every Physical Tenant, including default, opened the legacy
+  Zeebe exporter and is exporting. Fails if any tenant fell back to a
+  BlockingExporter or its exported position is stuck at -1, and fails if fewer
+  than two tenants report partitions. Stands in for the per-tenant Optimize
+  coverage the e2e suite cannot express yet, because Optimize reads the legacy
+  exporter and its records are the only thing a per-tenant Optimize can import.

--- a/charts/camunda-platform-8.10/test/ci/registry/hooks/physicaltenants-exporters.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/hooks/physicaltenants-exporters.yaml
@@ -1,8 +1,11 @@
 script: post-deploy-physical-tenant-exporters.sh
 description: |
   Asserts that every Physical Tenant, including default, opened the legacy
-  Zeebe exporter and is exporting. Fails if any tenant fell back to a
-  BlockingExporter or its exported position is stuck at -1, and fails if fewer
-  than two tenants report partitions. Stands in for the per-tenant Optimize
-  coverage the e2e suite cannot express yet, because Optimize reads the legacy
-  exporter and its records are the only thing a per-tenant Optimize can import.
+  Zeebe exporter and is exporting. Requires the reported tenant set to be
+  exactly default, tenanta and tenantb - the set this scenario declares - so a
+  tenant that never registered fails the hook rather than going unnoticed.
+  Each of them must report at least one partition, and fails if any tenant fell
+  back to a BlockingExporter or its exported position is stuck at -1. Stands in
+  for the per-tenant Optimize coverage the e2e suite cannot express yet, because
+  Optimize reads the legacy exporter and its records are the only thing a
+  per-tenant Optimize can import.

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -219,3 +219,7 @@ integration:
       shortname: mnop
       tier: 2
       enabled: true
+    - id: physicaltenants
+      shortname: ptnt
+      tier: 2
+      enabled: true

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/physicaltenants.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/physicaltenants.yaml
@@ -1,0 +1,71 @@
+name: physicaltenants
+auth: keycloak
+flows:
+  - install
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+# e2e is blocked on the test suite, not on the chart: the Optimize flows in
+# smoke-tests.spec.ts and optimize-user-flows.spec.ts create their data through
+# Web Modeler, which deploys over the plain /v2 path and so lands records in the
+# default tenant, while a per-tenant Optimize reads its own tenant's prefix and
+# finds nothing. The suite has no concept of a Physical Tenant, and
+# components.orchestration on the cluster record is singular, so one record
+# cannot name a tenant-scoped Modeler target per tenant. Skipping that one
+# dimension keeps the isolation, initialization and per-tenant export coverage
+# below, which the post-deploy hook asserts. Drop this key once the e2e suite can
+# address an Optimize per tenant.
+skip-e2e: true
+post-deploy: physicaltenants-exporters
+topology:
+  name: hub-1orch-2tenants
+  shared-storage: elasticsearch
+  shared-storage-service: elasticsearch-master
+  releases:
+    - role: hub
+      namespace-suffix: hub
+      identity: keycloak
+      dependencies:
+        - keycloak-fixed-issuer
+        - postgresql
+        - elasticsearch
+      features:
+        - multinamespace-reset-clients
+        - physicaltenants-hub
+    - role: orchestration
+      namespace-suffix: orcha
+      modeler-cluster-id: orcha
+      modeler-cluster-name: Orchestration A
+      identity: keycloak-external
+      persistence: elasticsearch-external
+      dependencies: []
+      features:
+        - physicaltenants-orchestration
+      depends-on: hub
+      env:
+        ORCH_ORCHESTRATION_CLIENT_ID: orchestration-orcha
+        ORCH_ORCHESTRATION_AUDIENCE: orchestration-orcha-api
+        ORCH_OPTIMIZE_CLIENT_ID: optimize-orcha-ta
+        ORCH_OPTIMIZE_AUDIENCE: optimize-orcha-api
+        ORCH_CONNECTORS_CLIENT_ID: connectors-orcha
+    - role: optimize
+      namespace-suffix: optta
+      serves: orcha
+      optimize-context-path: /optimize-orcha-ta
+      identity: keycloak-external-optimize
+      persistence: elasticsearch-external
+      dependencies: []
+      features:
+        - physicaltenants-optimize-ta
+      depends-on: hub
+    - role: optimize
+      namespace-suffix: opttb
+      serves: orcha
+      optimize-context-path: /optimize-orcha-tb
+      identity: keycloak-external-optimize
+      persistence: elasticsearch-external
+      dependencies: []
+      features:
+        - physicaltenants-optimize-tb
+      depends-on: hub

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-hub.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-hub.yaml
@@ -1,0 +1,95 @@
+# Hub namespace layer for the physicaltenants topology (8.10).
+#
+# One Orchestration Cluster whose two Physical Tenants each run their own
+# Optimize release. The cluster record registers tenant A's Optimize client and
+# the shared optimize-orcha-api resource server; tenant B's client is added
+# through identity.clients[] because
+# global.topology.clusters[].components.optimize is singular and cannot describe
+# a second Optimize for one cluster. Both clients therefore share one audience —
+# identity-separated, not authorization-isolated.
+#
+# NOTE: avoid writing literal dollar-brace placeholder syntax in prose comments
+# in this file — the env var scanner (os.Expand-based) matches it anywhere in the
+# raw file content, including comments. Reference placeholder names in plain text
+# instead; the real placeholder syntax appears only in actual values below.
+
+global:
+  elasticsearch:
+    enabled: false
+  identity:
+    auth:
+      orchestration:
+        hubPingAuthorizationEnabled: true
+  topology:
+    mode: hub
+    clusters:
+      - id: orcha
+        name: Orchestration A
+        namespace: "${ORCHA_NAMESPACE}"
+        releaseName: integration
+        host: "${ORCHA_HOST}"
+        version: "8.10.0-alpha3"
+        contextPaths:
+          orchestration: /orchestration
+          optimize: "${OPTTA_OPTIMIZE_CONTEXT_PATH}"
+          connectors: /connectors
+        components:
+          orchestration:
+            enabled: true
+            clientId: orchestration-orcha
+            audience: orchestration-orcha-api
+            redirectUrl: "https://${ORCHA_HOST}/orchestration"
+            secret:
+              existingSecret: integration-test-credentials
+              existingSecretKey: identity-orchestration-client-token
+          optimize:
+            enabled: true
+            clientId: optimize-orcha-ta
+            audience: optimize-orcha-api
+            redirectUrl: "https://${HUB_HOST}${OPTTA_OPTIMIZE_CONTEXT_PATH}"
+            secret:
+              existingSecret: integration-test-credentials
+              existingSecretKey: identity-optimize-client-token
+          connectors:
+            enabled: true
+            clientId: connectors-orcha
+            secret:
+              existingSecret: integration-test-credentials
+              existingSecretKey: identity-connectors-client-token
+
+identity:
+  clients:
+    - id: optimize-orcha-tb
+      name: Optimize Orchestration A tenantb
+      type: confidential
+      secret:
+        existingSecret: integration-test-credentials
+        existingSecretKey: identity-optimize-client-token
+      rootUrl: "https://${HUB_HOST}${OPTTB_OPTIMIZE_CONTEXT_PATH}"
+      redirectUris: /api/authentication/callback
+      permissions:
+        - resourceServerId: optimize-orcha-api
+          definition: write:*
+        - resourceServerId: camunda-identity-resource-server
+          definition: read:users
+    - id: venom
+      name: Venom
+      secret:
+        existingSecret: integration-test-credentials
+        existingSecretKey: identity-admin-client-password
+      redirectUris: /dummy
+      rootUrl: http://dummy
+      type: confidential
+      permissions:
+        - resourceServerId: camunda-identity-resource-server
+          definition: read
+        - resourceServerId: camunda-identity-resource-server
+          definition: write
+        - resourceServerId: orchestration-orcha-api
+          definition: read:*
+        - resourceServerId: orchestration-orcha-api
+          definition: write:*
+        - resourceServerId: optimize-orcha-api
+          definition: write:*
+        - resourceServerId: web-modeler-api
+          definition: write:*

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-hub.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-hub.yaml
@@ -14,8 +14,6 @@
 # instead; the real placeholder syntax appears only in actual values below.
 
 global:
-  elasticsearch:
-    enabled: false
   identity:
     auth:
       orchestration:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-optimize-ta.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-optimize-ta.yaml
@@ -1,0 +1,52 @@
+# Optimize-only release for Physical Tenant "tenanta" (physicaltenants topology, 8.10).
+#
+# global.topology.mode=optimize gates every other component off, so this file
+# carries no enabled: false block.
+#
+# NOTE: avoid writing literal dollar-brace placeholder syntax in prose comments
+# in this file — the env var scanner (os.Expand-based) matches it anywhere in the
+# raw file content, including comments. Reference placeholder names in plain text
+# instead; the real placeholder syntax appears only in actual values below.
+#
+# The reader prefix is the ORCHA cluster's prefix with this tenant's suffix,
+# matching this tenant's exporter index prefix under camunda.physical-tenants in
+# features/physicaltenants-orchestration.yaml. OPTIMIZE_INDEX_PREFIX is derived
+# per release namespace, so the two Optimizes never share index space.
+#
+# NOTE ON AUTHORIZATION: both tenants' Optimize clients share the audience
+# optimize-orcha-api. global.topology.clusters[].components.optimize is singular,
+# so the hub can register a second client for tenant B via identity.clients[] but
+# cannot register a second resource server, and a client permission must name an
+# existing one. Per-tenant Optimize audiences therefore are not expressible in
+# the cluster record today: the two instances are identity-separated but not
+# authorization-isolated.
+
+global:
+  topology:
+    mode: optimize
+
+optimize:
+  enabled: true
+  livenessProbe:
+    enabled: true
+  security:
+    authentication:
+      oidc:
+        clientId: "optimize-orcha-ta"
+        audience: "optimize-orcha-api"
+        redirectUrl: "https://${HUB_HOST}${RELEASE_OPTIMIZE_CONTEXT_PATH}"
+        secret:
+          existingSecret: integration-test-credentials
+          existingSecretKey: identity-optimize-client-token
+  contextPath: "${RELEASE_OPTIMIZE_CONTEXT_PATH}"
+  database:
+    elasticsearch:
+      enabled: true
+      external: true
+      url:
+        protocol: "${EXTERNAL_ELASTICSEARCH_SCHEME}"
+        host: "${EXTERNAL_ELASTICSEARCH_HOST}"
+      prefix: "${SERVED_ORCHESTRATION_INDEX_PREFIX}-ta"
+  env:
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX
+      value: $OPTIMIZE_INDEX_PREFIX

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-optimize-tb.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-optimize-tb.yaml
@@ -1,0 +1,52 @@
+# Optimize-only release for Physical Tenant "tenantb" (physicaltenants topology, 8.10).
+#
+# global.topology.mode=optimize gates every other component off, so this file
+# carries no enabled: false block.
+#
+# NOTE: avoid writing literal dollar-brace placeholder syntax in prose comments
+# in this file — the env var scanner (os.Expand-based) matches it anywhere in the
+# raw file content, including comments. Reference placeholder names in plain text
+# instead; the real placeholder syntax appears only in actual values below.
+#
+# The reader prefix is the ORCHA cluster's prefix with this tenant's suffix,
+# matching this tenant's exporter index prefix under camunda.physical-tenants in
+# features/physicaltenants-orchestration.yaml. OPTIMIZE_INDEX_PREFIX is derived
+# per release namespace, so the two Optimizes never share index space.
+#
+# NOTE ON AUTHORIZATION: both tenants' Optimize clients share the audience
+# optimize-orcha-api. global.topology.clusters[].components.optimize is singular,
+# so the hub can register a second client for tenant B via identity.clients[] but
+# cannot register a second resource server, and a client permission must name an
+# existing one. Per-tenant Optimize audiences therefore are not expressible in
+# the cluster record today: the two instances are identity-separated but not
+# authorization-isolated.
+
+global:
+  topology:
+    mode: optimize
+
+optimize:
+  enabled: true
+  livenessProbe:
+    enabled: true
+  security:
+    authentication:
+      oidc:
+        clientId: "optimize-orcha-tb"
+        audience: "optimize-orcha-api"
+        redirectUrl: "https://${HUB_HOST}${RELEASE_OPTIMIZE_CONTEXT_PATH}"
+        secret:
+          existingSecret: integration-test-credentials
+          existingSecretKey: identity-optimize-client-token
+  contextPath: "${RELEASE_OPTIMIZE_CONTEXT_PATH}"
+  database:
+    elasticsearch:
+      enabled: true
+      external: true
+      url:
+        protocol: "${EXTERNAL_ELASTICSEARCH_SCHEME}"
+        host: "${EXTERNAL_ELASTICSEARCH_HOST}"
+      prefix: "${SERVED_ORCHESTRATION_INDEX_PREFIX}-tb"
+  env:
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX
+      value: $OPTIMIZE_INDEX_PREFIX

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-orchestration.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/physicaltenants-orchestration.yaml
@@ -1,0 +1,132 @@
+# Orchestration namespace layer for the physicaltenants topology (8.10).
+#
+# One Orchestration Cluster hosting two Physical Tenants beside the always-present
+# default tenant, with Optimize deployed as its own release per tenant (see
+# features/physicaltenants-optimize-*.yaml).
+#
+# NOTE: avoid writing literal dollar-brace placeholder syntax in prose comments
+# in this file — the env var scanner (os.Expand-based) matches it anywhere in
+# the raw file content, including comments. Reference placeholder names in plain
+# text instead; the real placeholder syntax appears only in actual values below.
+#
+# Tenant index prefixes are derived from this release's own
+# ORCHESTRATION_INDEX_PREFIX so the Optimize releases can reconstruct them from
+# the topology driver's ORCHA_ORCHESTRATION_INDEX_PREFIX cross-ref env without a
+# second source of truth.
+
+global:
+  identity:
+    auth:
+      # The exact "iss" the companion Keycloak mints. Required once Physical
+      # Tenants are configured: the cluster then validates "iss" on every token,
+      # and the chart deliberately does not infer this from publicIssuerUrl. The
+      # dependency keycloak-fixed-issuer pins KC_HOSTNAME to this same value, so
+      # in-cluster callers and browsers present one issuer.
+      issuer: "https://${HUB_HOST}/auth/realms/camunda-platform"
+
+orchestration:
+  data:
+    secondaryStorage:
+      type: elasticsearch
+      elasticsearch:
+        url: "${EXTERNAL_ELASTICSEARCH_SCHEME}://${EXTERNAL_ELASTICSEARCH_HOST}:${EXTERNAL_ELASTICSEARCH_PORT}"
+  index:
+    prefix: $ORCHESTRATION_INDEX_PREFIX
+  exporters:
+    # Optimize reads zeebe-record indices, so this release runs the legacy
+    # exporter even though no Optimize workload lives here. Each tenant's own
+    # exporter is declared per tenant below, keyed by that tenant's prefix.
+    zeebe:
+      enabled: true
+  extraConfiguration:
+    - file: physical-tenants.yaml
+      content: |
+        camunda:
+          physical-tenants:
+            # The default tenant needs an explicit exporter: declaring any tenant
+            # stops it inheriting zeebe.broker.exporters from the root, and it
+            # would then silently stop exporting the records its own Optimize
+            # reads. Its prefix is the root prefix, distinct from every tenant's.
+            default:
+              data:
+                exporters-assigned:
+                  - elasticsearch
+                exporters:
+                  elasticsearch:
+                    className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+                    args:
+                      url: "${EXTERNAL_ELASTICSEARCH_SCHEME}://${EXTERNAL_ELASTICSEARCH_HOST}:${EXTERNAL_ELASTICSEARCH_PORT}"
+                      index:
+                        prefix: "${ORCHESTRATION_INDEX_PREFIX}"
+                        numberOfReplicas: "1"
+              security:
+                authentication:
+                  providers:
+                    assigned:
+                      - oidc
+            tenanta:
+              data:
+                secondary-storage:
+                  elasticsearch:
+                    index-prefix: "${ORCHESTRATION_INDEX_PREFIX}-ta"
+                exporters-assigned:
+                  - elasticsearch
+                exporters:
+                  elasticsearch:
+                    className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+                    args:
+                      url: "${EXTERNAL_ELASTICSEARCH_SCHEME}://${EXTERNAL_ELASTICSEARCH_HOST}:${EXTERNAL_ELASTICSEARCH_PORT}"
+                      index:
+                        prefix: "${ORCHESTRATION_INDEX_PREFIX}-ta"
+                        numberOfReplicas: "1"
+              security:
+                authentication:
+                  providers:
+                    assigned:
+                      - oidc
+                initialization:
+                  default-roles:
+                    admin:
+                      clients:
+                        - venom
+                      users:
+                        - demo
+            tenantb:
+              data:
+                secondary-storage:
+                  elasticsearch:
+                    index-prefix: "${ORCHESTRATION_INDEX_PREFIX}-tb"
+                exporters-assigned:
+                  - elasticsearch
+                exporters:
+                  elasticsearch:
+                    className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+                    args:
+                      url: "${EXTERNAL_ELASTICSEARCH_SCHEME}://${EXTERNAL_ELASTICSEARCH_HOST}:${EXTERNAL_ELASTICSEARCH_PORT}"
+                      index:
+                        prefix: "${ORCHESTRATION_INDEX_PREFIX}-tb"
+                        numberOfReplicas: "1"
+              security:
+                authentication:
+                  providers:
+                    assigned:
+                      - oidc
+                initialization:
+                  default-roles:
+                    admin:
+                      clients:
+                        - venom
+                      users:
+                        - demo
+
+optimize:
+  # identity/keycloak-external.yaml enables Optimize for the single-release
+  # multinamespace topologies; here each tenant gets its own Optimize release.
+  enabled: false
+  database:
+    elasticsearch:
+      # Root legacy exporter prefix, serving the default Physical Tenant only.
+      prefix: $ORCHESTRATION_INDEX_PREFIX
+
+connectors:
+  enabled: true

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external-optimize.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external-optimize.yaml
@@ -1,6 +1,6 @@
 # External-Keycloak identity layer for Optimize-only releases (8.10)
-# Layer 3 (auth method), per-release override: used ONLY by releases with
-# role "optimize" in the multinamespace-optimize topology.
+# Layer 3 (auth method), per-release override: used by releases with role
+# "optimize" in the multinamespace-optimize and physicaltenants topologies.
 #
 # Unlike identity/keycloak-external.yaml, this layer configures no
 # Orchestration Cluster or Connectors auth — an Optimize release runs neither.
@@ -20,7 +20,8 @@
 #
 # The Optimize client id, audience, redirect URL, context path, and index
 # prefixes are per release and come from the matching
-# features/multinamespace-optimize-<suffix>.yaml layer.
+# features/multinamespace-optimize-<suffix>.yaml or
+# features/physicaltenants-optimize-<suffix>.yaml layer.
 
 global:
   host: "$CAMUNDA_HOSTNAME"

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-physical-tenant-exporters.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-physical-tenant-exporters.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright 2026 Camunda Services GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+NAMESPACE="${TEST_NAMESPACE:?TEST_NAMESPACE must be set}"
+RELEASE="${RELEASE_NAME:-integration}"
+CONTEXT_ARGS=()
+if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  CONTEXT_ARGS=(--context "${KUBE_CONTEXT}")
+fi
+
+fail() {
+  echo "$1" >&2
+  echo "--- partitions ---" >&2
+  echo "${partitions:-<none>}" >&2
+  echo "--- exporter log lines ---" >&2
+  grep -E 'broker\.exporter\.(elasticsearch|opensearch)|BlockingExporter' <<<"${broker_log:-}" >&2 || true
+  exit 1
+}
+
+partitions_are_healthy() {
+  jq -e '
+    (keys | sort) == ["default", "tenanta", "tenantb"]
+    and all(.default, .tenanta, .tenantb;
+      type == "array"
+      and length > 0
+      and all(.[]; .exporterPhase == "EXPORTING" and .exportedPosition >= 0))
+  ' >/dev/null 2>&1
+}
+
+PORT_FORWARD_LOG="$(mktemp)"
+kubectl "${CONTEXT_ARGS[@]}" -n "${NAMESPACE}" port-forward \
+  "statefulset/${RELEASE}-zeebe" ":9600" >"${PORT_FORWARD_LOG}" 2>&1 &
+PORT_FORWARD_PID=$!
+trap 'kill "${PORT_FORWARD_PID}" 2>/dev/null || true; rm -f "${PORT_FORWARD_LOG}"' EXIT
+
+# kubectl picks the local port when it is left empty; read it back from its first line.
+LOCAL_PORT=""
+for _ in {1..30}; do
+  LOCAL_PORT="$(sed -nE 's/^Forwarding from 127\.0\.0\.1:([0-9]+).*/\1/p' "${PORT_FORWARD_LOG}" | head -1)"
+  [[ -n "${LOCAL_PORT}" ]] && break
+  sleep 1
+done
+if [[ -z "${LOCAL_PORT}" ]]; then
+  echo "Port-forward to ${RELEASE}-zeebe management port never reported a local port." >&2
+  cat "${PORT_FORWARD_LOG}" >&2
+  exit 1
+fi
+
+# The management endpoints sit under the Orchestration Cluster context path when one is
+# configured, so probe both rather than assuming the chart default.
+ACTUATOR=""
+for candidate in "/orchestration/actuator" "/actuator"; do
+  if curl --silent --fail --max-time 10 "http://127.0.0.1:${LOCAL_PORT}${candidate}" >/dev/null 2>&1; then
+    ACTUATOR="${candidate}"
+    break
+  fi
+done
+if [[ -z "${ACTUATOR}" ]]; then
+  echo "Could not reach the broker actuator on the management port." >&2
+  exit 1
+fi
+
+# /actuator/partitions is keyed by physical tenant id, so it is both the tenant inventory
+# and the per-tenant exporting state. A tenant whose exporter config is missing while its
+# partition state still enables the id runs a BlockingExporter: exporting pauses and the
+# exported position stays at -1, which also stops log compaction for those entries.
+partitions=""
+for attempt in {1..60}; do
+  # kubectl port-forward exits with its target pod; without this the remaining attempts curl
+  # a dead local port and the diagnostics blame the tenant exporters.
+  kill -0 "${PORT_FORWARD_PID}" 2>/dev/null || {
+    echo "Port-forward to ${RELEASE}-zeebe died before every physical tenant reported exporting." >&2
+    cat "${PORT_FORWARD_LOG}" >&2
+    fail "Lost the management port while waiting for physical tenants to export."
+  }
+
+  partitions="$(curl --silent --show-error --max-time 10 \
+    "http://127.0.0.1:${LOCAL_PORT}${ACTUATOR}/partitions" 2>/dev/null)" || true
+
+  if partitions_are_healthy <<<"${partitions}"; then
+    break
+  fi
+
+  if (( attempt == 60 )); then
+    fail "Physical tenants did not all reach a healthy exporting state."
+  fi
+  echo "Waiting for every physical tenant to export (attempt ${attempt}/60)..."
+  sleep 5
+done
+
+mapfile -t TENANTS < <(jq -r 'keys[]' <<<"${partitions}")
+echo "Physical tenants reporting partitions: ${TENANTS[*]}"
+
+broker_log="$(kubectl "${CONTEXT_ARGS[@]}" logs -n "${NAMESPACE}" \
+  "statefulset/${RELEASE}-zeebe" --all-containers)"
+
+if grep -q 'BlockingExporter' <<<"${broker_log}"; then
+  fail "A physical tenant fell back to a BlockingExporter: an exporter id is enabled in the partition state but its configuration is missing."
+fi
+
+# Optimize reads the legacy exporter, not the Camunda exporter, so a per-tenant Optimize is
+# only fed if the legacy exporter opens on that tenant's partitions.
+for tenant in "${TENANTS[@]}"; do
+  if ! grep -E 'broker\.exporter\.(elasticsearch|opensearch)' <<<"${broker_log}" \
+      | grep -qE "physicalTenant=${tenant}[},]"; then
+    fail "The legacy exporter never opened for physical tenant '${tenant}'."
+  fi
+done
+
+echo "Legacy exporter opened for all ${#TENANTS[@]} physical tenants, with no blocked exporters."

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-physical-tenant-exporters.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-physical-tenant-exporters.sh
@@ -32,10 +32,11 @@ fail() {
 }
 
 partitions_are_healthy() {
+  # Each tenant maps to an object keyed by partition id: {"tenanta":{"1":{...}}}.
   jq -e '
     (keys | sort) == ["default", "tenanta", "tenantb"]
     and all(.default, .tenanta, .tenantb;
-      type == "array"
+      (type == "object" or type == "array")
       and length > 0
       and all(.[]; .exporterPhase == "EXPORTING" and .exportedPosition >= 0))
   ' >/dev/null 2>&1

--- a/test/integration/companion-values/keycloak-fixed-issuer.yaml
+++ b/test/integration/companion-values/keycloak-fixed-issuer.yaml
@@ -1,0 +1,55 @@
+# Companion values for internal-keycloak-26 with a pinned frontend URL.
+#
+# Identical to keycloak.yaml apart from KC_HOSTNAME. The base chart passes
+# --hostname-strict=false, so Keycloak derives its issuer from the request host:
+# a caller reaching the internal Service gets an internal issuer while a browser
+# reaching the ingress gets the public one. Physical Tenants require the
+# Orchestration Cluster to validate a single issuer-uri, which no request-derived
+# issuer can satisfy for both callers, so this variant pins one.
+#
+# KC_HOSTNAME must include the /auth path. Keycloak 26 builds frontend URLs from
+# the pinned hostname URL alone and does not append --http-relative-path to it, so
+# omitting the path yields https://<host>/realms/... and no longer matches the
+# chart's publicIssuerUrl, https://<host>/auth/realms/camunda-platform. Verified
+# against Keycloak 26.3.3 by reading the discovery document both ways.
+
+fullnameOverride: keycloak
+
+image:
+  registry: quay.io
+  repository: keycloak/keycloak
+  tag: "26.3.3"
+
+auth:
+  adminUser: admin
+  existingSecret: integration-test-credentials
+  passwordSecretKey: identity-keycloak-admin-password
+
+httpRelativePath: "/auth/"
+proxy: edge
+
+extraEnv:
+  - name: KC_HOSTNAME
+    value: "https://${CAMUNDA_HOSTNAME}/auth"
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+postgresql:
+  enabled: true
+  auth:
+    database: keycloak
+    username: keycloak
+    password: "keycloak-ci-password"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi

--- a/test/integration/companion-values/keycloak-fixed-issuer.yaml
+++ b/test/integration/companion-values/keycloak-fixed-issuer.yaml
@@ -3,8 +3,8 @@
 # Identical to keycloak.yaml apart from KC_HOSTNAME. The base chart passes
 # --hostname-strict=false, so Keycloak derives its issuer from the request host:
 # a caller reaching the internal Service gets an internal issuer while a browser
-# reaching the ingress gets the public one. Physical Tenants require the
-# Orchestration Cluster to validate a single issuer-uri, which no request-derived
+# reaching the ingress gets the public one. The Orchestration Cluster validates
+# the refresh_token grant against a single issuer, which no request-derived
 # issuer can satisfy for both callers, so this variant pins one.
 #
 # KC_HOSTNAME must include the /auth path. Keycloak 26 builds frontend URLs from

--- a/test/scripts/physical_tenant_exporters.bats
+++ b/test/scripts/physical_tenant_exporters.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+setup() {
+  ROOT="$(git -C "$(dirname "${BATS_TEST_FILENAME}")" rev-parse --show-toplevel)"
+  SCRIPT="$ROOT/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-physical-tenant-exporters.sh"
+  eval "$(sed -n '/^partitions_are_healthy() {/,/^}/p' "$SCRIPT")"
+}
+
+@test "partition validation accepts the complete healthy tenant set" {
+  run partitions_are_healthy <<'EOF'
+{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenanta":[{"exporterPhase":"EXPORTING","exportedPosition":2}],"tenantb":[{"exporterPhase":"EXPORTING","exportedPosition":3}]}
+EOF
+
+  [ "$status" -eq 0 ]
+}
+
+@test "partition validation rejects omission of either configured tenant" {
+  run partitions_are_healthy <<'EOF'
+{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenanta":[{"exporterPhase":"EXPORTING","exportedPosition":2}]}
+EOF
+  [ "$status" -ne 0 ]
+
+  run partitions_are_healthy <<'EOF'
+{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenantb":[{"exporterPhase":"EXPORTING","exportedPosition":3}]}
+EOF
+  [ "$status" -ne 0 ]
+}
+
+@test "partition validation rejects a tenant without partitions" {
+  run partitions_are_healthy <<'EOF'
+{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenanta":[],"tenantb":[{"exporterPhase":"EXPORTING","exportedPosition":3}]}
+EOF
+
+  [ "$status" -ne 0 ]
+}

--- a/test/scripts/physical_tenant_exporters.bats
+++ b/test/scripts/physical_tenant_exporters.bats
@@ -11,9 +11,20 @@ setup() {
   eval "$(sed -n '/^partitions_are_healthy() {/,/^}/p' "$SCRIPT")"
 }
 
+# Fixtures mirror /orchestration/actuator/partitions: each tenant maps to an object keyed by
+# partition id, not to an array.
+
 @test "partition validation accepts the complete healthy tenant set" {
   run partitions_are_healthy <<'EOF'
-{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenanta":[{"exporterPhase":"EXPORTING","exportedPosition":2}],"tenantb":[{"exporterPhase":"EXPORTING","exportedPosition":3}]}
+{"default":{"1":{"exporterPhase":"EXPORTING","exportedPosition":908}},"tenanta":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}},"tenantb":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}}}
+EOF
+
+  [ "$status" -eq 0 ]
+}
+
+@test "partition validation accepts a tenant with several partitions" {
+  run partitions_are_healthy <<'EOF'
+{"default":{"1":{"exporterPhase":"EXPORTING","exportedPosition":908},"2":{"exporterPhase":"EXPORTING","exportedPosition":12}},"tenanta":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}},"tenantb":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}}}
 EOF
 
   [ "$status" -eq 0 ]
@@ -21,19 +32,36 @@ EOF
 
 @test "partition validation rejects omission of either configured tenant" {
   run partitions_are_healthy <<'EOF'
-{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenanta":[{"exporterPhase":"EXPORTING","exportedPosition":2}]}
+{"default":{"1":{"exporterPhase":"EXPORTING","exportedPosition":908}},"tenanta":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}}}
 EOF
   [ "$status" -ne 0 ]
 
   run partitions_are_healthy <<'EOF'
-{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenantb":[{"exporterPhase":"EXPORTING","exportedPosition":3}]}
+{"default":{"1":{"exporterPhase":"EXPORTING","exportedPosition":908}},"tenantb":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}}}
 EOF
   [ "$status" -ne 0 ]
 }
 
 @test "partition validation rejects a tenant without partitions" {
   run partitions_are_healthy <<'EOF'
-{"default":[{"exporterPhase":"EXPORTING","exportedPosition":1}],"tenanta":[],"tenantb":[{"exporterPhase":"EXPORTING","exportedPosition":3}]}
+{"default":{"1":{"exporterPhase":"EXPORTING","exportedPosition":908}},"tenanta":{},"tenantb":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}}}
+EOF
+
+  [ "$status" -ne 0 ]
+}
+
+@test "partition validation rejects a tenant that is not exporting" {
+  run partitions_are_healthy <<'EOF'
+{"default":{"1":{"exporterPhase":"EXPORTING","exportedPosition":908}},"tenanta":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}},"tenantb":{"1":{"exporterPhase":"PAUSED","exportedPosition":164}}}
+EOF
+
+  [ "$status" -ne 0 ]
+}
+
+# A BlockingExporter keeps the phase at EXPORTING while the position stays at -1.
+@test "partition validation rejects a blocked exporter still reporting EXPORTING" {
+  run partitions_are_healthy <<'EOF'
+{"default":{"1":{"exporterPhase":"EXPORTING","exportedPosition":908}},"tenanta":{"1":{"exporterPhase":"EXPORTING","exportedPosition":164}},"tenantb":{"1":{"exporterPhase":"EXPORTING","exportedPosition":-1}}}
 EOF
 
   [ "$status" -ne 0 ]

--- a/test/scripts/physical_tenant_exporters.bats
+++ b/test/scripts/physical_tenant_exporters.bats
@@ -1,7 +1,12 @@
 #!/usr/bin/env bats
 
 setup() {
-  ROOT="$(git -C "$(dirname "${BATS_TEST_FILENAME}")" rev-parse --show-toplevel)"
+  here="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+  if ROOT="$(git -C "$here" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    ROOT="$(cd "$here/../.." && pwd)"
+  fi
   SCRIPT="$ROOT/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-physical-tenant-exporters.sh"
   eval "$(sed -n '/^partitions_are_healthy() {/,/^}/p' "$SCRIPT")"
 }


### PR DESCRIPTION
### Which problem does the PR fix?

Part of #6749. Nothing in CI configured a Physical Tenant, so #6889's values surface had no
deployment-level coverage and the per-tenant Optimize shape was untested.

### What's in this PR?

A `physicaltenants` scenario (`ptnt`, tier 2, enabled, `skip-e2e: true` — see below): hub + one
Orchestration Cluster hosting `tenanta` and `tenantb` beside the always-present default tenant, with
a `mode: optimize` release per tenant.

Scoped to **one** cluster with two tenants rather than two clusters with two tenants each. The
two-cluster dimension is already covered by `multinamespace-optimize`; adding it here would double
the cluster cost for no new information.

### What the live run established

Run on `distro-ci` against 8.10 alpha4:

- **Three tenants run as genuinely separate execution units.** The broker reached Ready with
  0 restarts, and its log MDC shows independent partition actors per tenant —
  `physicalTenant=default`, `=tenanta`, `=tenantb`.
- **Per-tenant `security.initialization` is applied per tenant**, which is the requirement #6889
  discovered and the docs omit. Each tenant has its own populated `camunda-role` (10 docs),
  `camunda-authorization` (56), `camunda-tenant` (6) and `camunda-mapping-rule` (3) index families.
- **Tenant-scoped export works end to end.** A process deployed through
  `/physical-tenants/tenanta/v2/deployments` produced a document in
  `…-ta-operate-process`, while the default and `-tb` families stayed empty. Both tenants'
  `/physical-tenants/<id>/v2/topology` returned 200 with a real token, and an undeclared tenant
  returned 404.
- **Three disjoint 40-index families** — default, `-ta`, `-tb` — from `index.prefix` alone.

### Why e2e is skipped

An earlier revision of this PR shipped the scenario disabled, pending an engine owner answering
whether the legacy exporter scopes per tenant. **That turned out to be a chart defect, not an engine
question** — `BrokerBasedPropertiesOverride.convert` does not inherit legacy `zeebe.broker.*`
properties for a non-default tenant, so the exporter was dropped for every tenant. PR 2 now assigns
it per tenant, and the deploy-level assertions above are worth running, so the scenario is enabled.

**e2e stays off, because that blocker is in the test suite, not the chart.** The Optimize flows in
`smoke-tests.spec.ts` (`Most Common Flow User Flow With All Apps`) and `optimize-user-flows.spec.ts`
create their data through **Web Modeler**, which deploys over the plain `/v2/...` path — and per the
Physical Tenants API-routing contract a plain `/v2` request targets the **`default`** tenant. The
records therefore land in the default tenant's index family while a per-tenant Optimize reads its
own tenant's prefix and finds nothing, so the report step fails. The smoke leg does not dodge this:
the data-dependent flow is in the smoke spec.

Two facts make this a genuine follow-up rather than a small fix:

- The e2e suite has **no concept of a Physical Tenant** at all — no tenant-scoped base URL, no
  `/physical-tenants/<id>` routing, no fixture.
- `global.topology.clusters[].components.orchestration` is **singular**, the same limitation as
  `components.optimize` below, so one cluster record cannot describe a tenant-scoped Modeler target
  for each tenant. Modeler could feed one tenant per cluster, never both.

`skip-e2e` keeps the isolation, initialization and per-tenant export coverage in the matrix rather
than forfeiting all of it to one blocked dimension. Pointing each per-tenant Optimize at the
*default* tenant's prefix would make e2e pass, and was rejected: it would assert the opposite of what
the scenario claims.

### A post-deploy hook covers what e2e cannot yet

Skipping e2e would otherwise leave the behaviour per-tenant Optimize depends on completely unchecked,
and both exporter defects this work uncovered were invisible to every existing gate. So the scenario
carries `post-deploy: physicaltenants-exporters`, which asserts against the live broker that:

- every Physical Tenant opened the **legacy** exporter, the one Optimize reads;
- no tenant fell back to a `BlockingExporter`, which is how a missing config surfaces when the
  partition state still enables the exporter id;
- at least two tenants report partitions, so the hook cannot pass on a deployment that quietly
  stopped configuring tenants.

Tenants are discovered from `/actuator/partitions` instead of by parsing the rendered config, keeping
the hook to `kubectl`, `curl` and `jq` like the other post-deploy scripts. A topology scenario's
`post-deploy` runs against the orchestration release, so it executes once in the namespace owning the
broker.

Both the log check and the exported-position check are kept deliberately. A cluster that exported
before its exporter config went missing keeps its persisted position, so only the log evidence catches
that case; a fresh deploy trips both.

Verified in both directions on `distro-ci` against 8.10 alpha4: exit 0 with the exporter fix applied,
exit 1 with it reverted, naming the blocked tenant.

### A second limitation, documented not solved

`global.topology.clusters[].components.optimize` is **singular**. Tenant B's client is therefore
registered through `identity.clients[]`, and both tenants share the `optimize-orcha-api` audience:
a client permission must name an existing resource server and only the cluster record creates one.
The two Optimize instances are identity-separated but **not** authorization-isolated. Real
per-tenant Optimize authorization needs the cluster record extended with a `physicalTenants` list —
a further PR, deliberately out of scope here.

### Verification

`go test ./...` in `scripts/deploy-camunda` passes, including the registry golden, which validates
the scenario's values/identity/persistence references, the `optimize` role's `serves` and
`optimize-context-path`, and `depends-on: hub`. The live evidence above came from
`deploy-camunda matrix run --shortname-filter ptnt --include-disabled`.

**The scenario is green on GKE.** A clean install on `distro-ci` against 8.10 alpha4 completed with
`deployment: success` and exit 0:

```
hub           (matrix-810-ptnt-inst-gke-hub)     OK
orchestration (matrix-810-ptnt-inst-gke-orcha)   OK
optimize      (matrix-810-ptnt-inst-gke-optta)   OK
optimize      (matrix-810-ptnt-inst-gke-opttb)   OK
```

What that run established, all from committed config with no hand patching:

- **The post-deploy hook passed in position**, invoked by the framework:
  `Legacy exporter opened for all 3 physical tenants, with no blocked exporters.`
- **Connectors reached 1/1 from a cold start with zero authentication errors.** It had never reached
  readiness before, which is what made every earlier run time out.
- **Keycloak mints one issuer.** Queried over the ClusterIP Service, the path that previously returned
  an internal issuer, discovery now reports
  `https://<hub-host>/auth/realms/camunda-platform`.
- **`issuer-uri` is present and `jwk-set-uri` absent**, so the value came from the explicit
  `global.identity.auth.issuer` key rather than an inferred one.
- **`mode: optimize` renders Optimize and nothing else.** Each Optimize namespace holds exactly one
  Deployment: no orchestration StatefulSet, no Identity, no Connectors, no Web Modeler.
- **Three disjoint index prefixes**, and each Optimize reads the *orchestration* release's prefix plus
  its own tenant suffix (`…-5b5ab5b4-ta`, `…-5b5ab5b4-tb`) rather than its own namespace-derived
  value. Conflating those would have made each Optimize read the wrong tenant's records.

### Design contracts inherited from #6884

This scenario is what fixes the strictness of the values-layer validator (contract 4 under
**Settled design contracts** in #6884). `physicaltenants-optimize-ta`/`-tb` set
`optimize.database.elasticsearch.prefix` to `${SERVED_ORCHESTRATION_INDEX_PREFIX}-ta`/`-tb`, because
each tenant's Optimize reads that tenant's slice of the served orchestration's records. The
validator therefore requires the placeholder to *lead* the prefix rather than to equal it; an
earlier exact-match rule passed every test in #6884 and failed this scenario's registry validation,
which is why contract 5 requires a validator change to be verified at the stack tip.

`optimize.contextPath` stays an exact `${RELEASE_OPTIMIZE_CONTEXT_PATH}` — the ingress path is the
declaration itself.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

- [ ] **Blocking:** GKE re-run on PR 2's exporter fix, confirming a `zeebe-record` index family per
  tenant at its own prefix and none shared with the default tenant.
- [x] Investigate why Connectors did not reach readiness in this topology. Answered: the broker
  validates `issuer-uri` from `publicIssuerUrl` while Connectors fetches its token from the
  internal Keycloak service and receives an internal `iss`, so the broker rejects it with
  `UNAUTHENTICATED: Invalid bearer token`. Connectors itself is already Physical-Tenant aware.
  Fixing it is tracked on #6889.
- [ ] Follow-up epic: make the e2e suite Physical-Tenant aware (tenant-scoped data creation and base
  URLs). The post-deploy hook stands in until then, but it stops short of proving records reach a
  per-tenant Optimize, because generating traffic needs a token and hits the issuer problem above.
- [ ] Extend `global.topology.clusters[]` with a `physicalTenants` list so each tenant's Optimize can
  own its audience — and so a tenant-scoped Modeler target becomes expressible.





