### PR TITLE
ci: decouple chart automation from support lifecycle and enable 8.6 validation

### DIFF
--- a/.claude/skills/deploy-camunda/SKILL.md
+++ b/.claude/skills/deploy-camunda/SKILL.md
@@ -219,7 +219,7 @@ The `qa-*` scenarios have `image-tags: true`, which includes `base-image-tags.ya
 
 ## Extended-Support Versions (Opt-In)
 
-Extended-support chart versions are excluded from the default matrix. `matrix run` reaches one only when it is named explicitly **and** its chart dir has a CI scenario registry (`test/ci/registry/manifest.yaml`). Among extended-support versions only **8.6** has one; `endOfLife` versions are unreachable through every path.
+The default matrix includes only `chartAutomation.routineVersions` from `charts/chart-versions.yaml`, independently of support-lifecycle metadata. A version outside that list is reachable when named explicitly **and** its chart dir has a CI scenario registry (`test/ci/registry/manifest.yaml`). **8.6** uses this opt-in path. A lifecycle `eolSince` entry blocks matrix execution, including explicit requests.
 
 Every 8.6 scenario is `enabled: false`, so `--include-disabled` is mandatory — without it the run yields no entries.
 

--- a/.claude/skills/deploy-camunda/SKILL.md
+++ b/.claude/skills/deploy-camunda/SKILL.md
@@ -221,7 +221,7 @@ The `qa-*` scenarios have `image-tags: true`, which includes `base-image-tags.ya
 
 The default matrix includes only `chartAutomation.routineVersions` from `charts/chart-versions.yaml`, independently of support-lifecycle metadata. A version outside that list is reachable when named explicitly **and** its chart dir has a CI scenario registry (`test/ci/registry/manifest.yaml`). **8.6** uses this opt-in path. A lifecycle `eolSince` entry blocks matrix execution, including explicit requests.
 
-Every 8.6 scenario is `enabled: false`, so `--include-disabled` is mandatory — without it the run yields no entries.
+Every 8.6 scenario is `enabled: false`, so `--include-disabled` is mandatory. If no enabled entries match but disabled entries satisfy the same filters, `matrix run` returns an error directing you to re-run with `--include-disabled`. Unmatched filters retain the normal no-match diagnostic, and `matrix list` still lists no entries without opt-in.
 
 ```bash
 # Validate a patched image against the 8.6 chart

--- a/.claude/skills/deploy-camunda/SKILL.md
+++ b/.claude/skills/deploy-camunda/SKILL.md
@@ -217,6 +217,88 @@ deploy-camunda matrix run \
 
 The `qa-*` scenarios have `image-tags: true`, which includes `base-image-tags.yaml` (with `$E2E_TESTS_*_IMAGE_TAG` placeholders) and excludes `values-digest.yaml`. The `--env-file` provides the actual values for substitution via `buildScenarioEnv()`. In CI, the workflow converts the `VALUES_CONFIG` JSON to a `.env` file using `jq` before calling `deploy-camunda`.
 
+## Extended-Support Versions (Opt-In)
+
+Extended-support chart versions are excluded from the default matrix. `matrix run` reaches one only when it is named explicitly **and** its chart dir has a CI scenario registry (`test/ci/registry/manifest.yaml`). Among extended-support versions only **8.6** has one; `endOfLife` versions are unreachable through every path.
+
+Every 8.6 scenario is `enabled: false`, so `--include-disabled` is mandatory — without it the run yields no entries.
+
+```bash
+# Validate a patched image against the 8.6 chart
+deploy-camunda matrix run \
+  --repo-root . \
+  --versions 8.6 \
+  --include-disabled \
+  --shortname-filter es \
+  --shortname-exact \
+  --flow-filter install \
+  --platform gke \
+  --ingress-base-domain-gke ci.distro.ultrawombat.com \
+  --extra-values /tmp/patched-image.yaml \
+  --ensure-docker-registry \
+  --docker-username "$HARBOR_USERNAME" \
+  --docker-password "$HARBOR_PASSWORD" \
+  --yes
+```
+
+Deliberately no `--cleanup`: that is the flag that deletes the namespace *after* the run, and a verification run needs it to survive so the pod can be inspected afterwards (below). Delete it yourself when done — `kubectl delete namespace <ns>`.
+
+`--delete-namespace` is a different thing: it deletes the namespace *before* deploying each entry, for a clean slate (internally `DeleteNamespaceFirst`). Omit it when an existing deployment must be preserved — `upgrade-patch` relies on that, and `runner_upgrade.go:320` forces it false for Step 2 because the namespace must persist from Step 1. So a namespace surviving an `upgrade-patch` run is expected when `--cleanup` is not set, not a bug.
+
+Expect the install to take ~4-5 minutes and to look broken in the middle of it: optimize's `migration` init container enters `CrashLoopBackOff` with `java.net.ConnectException: Connection refused` until the Elasticsearch cluster reports `status: green`. There is no readiness gate between them, so it retries until ES is up and then proceeds. Confirm ES before treating an optimize crashloop as a real failure:
+
+```bash
+kubectl exec -n $NS integration-elasticsearch-master-0 -- \
+  curl -s localhost:9200/_cluster/health | jq .status
+```
+
+8.6 shortnames: `es` (Keycloak + Elasticsearch), `os` (Keycloak + OpenSearch), `mt` (adds the `multitenancy` feature). `es` also carries `upgrade-patch` on `gke` and `eks`; the others are `install`/`gke` only.
+
+**`kcor` does not exist for 8.6 and is not needed.** The `keycloak-original-install` scenario (`kcor`/`keyco`) is defined only in the 8.8 and 8.9 registries. Use `es` instead — it selects the same configuration that matters for validating an image: Keycloak identity with Elasticsearch persistence. `--shortname-filter` matches by substring, so pair it with `--shortname-exact`. On 8.9 a bare `--shortname-filter es` returns 9 entries (`eske`, `esoi`, `esss`, `esot`, `esarm`); against 8.6's current three shortnames it happens to be unambiguous, but the exact flag keeps the invocation correct if the registry gains one.
+
+**Image override:** put the component's full image coordinates in the `--extra-values` file, including `pullSecrets`.
+
+```yaml
+identity:
+  image:
+    registry: registry.camunda.cloud
+    repository: team-identity/identity
+    tag: <patched-tag>
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
+global:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
+```
+
+Component-level pull-secret resolution is **exclusive**, not merged: setting `identity.image.pullSecrets` makes the chart ignore `global.image.pullSecrets` for that component. A global-only override therefore drops the secret and the pod lands in `ImagePullBackOff`.
+
+A digest overlay cannot shadow the tag here — 8.6 simply ships no `values-digest.yaml` (only 8.8/8.9/8.10 do). Matrix runs do select the digest overlay by default (`resolveChartRootOverlays`, `matrix/runner.go:79`), so on the versions that have one, `neutralizeOverriddenDigests` (`deploy/digest_overlay.go:51`, wired at `deploy/values.go:890`) strips the digest of any component whose image coordinates `--extra-values` overrides, so the tag still wins.
+
+**These scenarios never run e2e, even with `--test-e2e` or `--test-all`.** All three set `skip-e2e: true`, and the runner computes `RunE2ETests: (opts.TestE2E || opts.TestAll) && !entry.SkipE2E` (`matrix/runner_execute.go:250`) — the scenario flag wins unconditionally. This is deliberate: the cross-component e2e suite ships no `SM-8.6` fixture directory, and its Keycloak admin-console login locators do not match 8.6's older console. Verify a deploy by inspecting the running pod instead — image contents, startup logs, and the OIDC discovery document:
+
+```bash
+NS=<namespace>
+kubectl get pod -n $NS -l app.kubernetes.io/component=identity \
+  -o jsonpath='{range .items[*]}{.status.containerStatuses[0].image}{"\n"}{.status.containerStatuses[0].imageID}{"\n"}{end}'
+kubectl logs -n $NS -l app.kubernetes.io/component=identity | grep -iE "error|exception"
+curl -sk "https://$NS.ci.distro.ultrawombat.com/auth/realms/camunda-platform/.well-known/openid-configuration" | jq .issuer
+```
+
+The OIDC path uses the fixed `camunda-platform` realm — `values/identity/keycloak.yaml` hardcodes `publicIssuerUrl: .../auth/realms/camunda-platform` on every chart version. The per-scenario `realm:` value the run summary prints (e.g. `elasticsearch-0760899c`) is not a Keycloak realm path; using it returns `Realm does not exist`.
+
+For an extended-support version with **no** registry, `matrix run` fails with an error naming the missing manifest and pointing at the single-scenario path, which needs no registry:
+
+```bash
+deploy-camunda \
+  --scenario charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup \
+  --identity keycloak --persistence elasticsearch \
+  --namespace $NS --release $RELEASE
+```
+
 ## Render Without Deploying
 
 Debug values merging without touching the cluster:

--- a/.github/actions/get-chart-versions/action.yaml
+++ b/.github/actions/get-chart-versions/action.yaml
@@ -3,36 +3,9 @@
 name: Get chart versions
 description: Find chart versions that should be included in the CI matrix.
 outputs:
-  all:
-    description: All Camunda versions including alpha, standard support, extended support, and end-of-life versions.
-    value: ${{ steps.get-chart-versions.outputs.all }}
   active:
-    description: Versions with standard support and alpha versions. 
+    description: Versions selected for routine chart automation.
     value: ${{ steps.get-chart-versions.outputs.active }}
-  alpha:
-    description: Alpha versions. 
-    value: ${{ steps.get-chart-versions.outputs.alpha }}
-  support-standard:
-    description: Standard support versions.
-    value: ${{ steps.get-chart-versions.outputs.support-standard }}
-  support-standard-newest:
-    description: |
-      The newest/latest standard support version.
-      For example, if the standard supported versions are 8.1, 8.2, 8.3, then the newest is 8.3 version.
-    value: ${{ steps.get-chart-versions.outputs.support-standard-newest }}
-  support-standard-oldest:
-    description: |
-      The oldest/earliest standard support version.
-      For example, if the standard supported versions are 8.1, 8.2, 8.3, then the oldest is 8.1 version.
-    value: ${{ steps.get-chart-versions.outputs.support-standard-oldest }}
-  support-extended:
-    description: |
-      Extended support versions.
-      Usually these are the versions that are no longer supported by Camunda, but still have extended support.
-    value: ${{ steps.get-chart-versions.outputs.support-extended }}
-  end-of-life:
-    description: End-of-life versions (no support at all for those versions).
-    value: ${{ steps.get-chart-versions.outputs.end-of-life }}
 
 runs:
   using: composite
@@ -43,14 +16,5 @@ runs:
       id: get-chart-versions
       run: |
         chart_versions_file="charts/chart-versions.yaml"
-        cat << EOF | sed 's/^\s\+//g' >> $GITHUB_OUTPUT
-          all=$(yq '.camundaVersions | to_entries | map(.value) | flatten | join(" ")' ${chart_versions_file})
-          active=$(yq '.camundaVersions.alpha + .camundaVersions.supportStandard | join(" ")' ${chart_versions_file})
-          alpha=$(yq '.camundaVersions.alpha | join(" ")' ${chart_versions_file})
-          support-standard=$(yq '.camundaVersions.supportStandard | join(" ")' ${chart_versions_file})
-          support-standard-newest=$(yq '.camundaVersions.supportStandard.[0]' ${chart_versions_file})
-          support-standard-oldest=$(yq '.camundaVersions.supportStandard.[-1]' ${chart_versions_file})
-          support-extended=$(yq '.camundaVersions.supportExtended | join(" ")' ${chart_versions_file})
-          end-of-life=$(yq '.camundaVersions.endOfLife | join(" ")' ${chart_versions_file})
-        EOF
-        echo "All versions outputs set successfully."
+        yq -e '.chartAutomation.routineVersions | tag == "!!seq"' "$chart_versions_file" > /dev/null
+        echo "active=$(yq '.chartAutomation.routineVersions | join(" ")' "$chart_versions_file")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -193,7 +193,7 @@ jobs:
           echo "package_file=${package_name}" | tee -a $GITHUB_OUTPUT
           
           # Extract version, app_version (appVersion, .x-stripped), prerelease,
-          # is_latest_stable (vs chart-versions.yaml supportStandard[0]),
+          # is_latest_stable (vs the newest released minor in chart-versions.yaml),
           # chart_dir_id, release_tag, the cosign file names and the
           # component-image-versions annotation from the package's Chart.yaml.
           tar -xzf "${package_file}" camunda-platform/Chart.yaml -O > /tmp/Chart.yaml

--- a/.github/workflows/chart-validate-docs-links.yaml
+++ b/.github/workflows/chart-validate-docs-links.yaml
@@ -11,7 +11,7 @@ on:
       chart-version:
         description: |
           Specific chart version to check (e.g., "8.8"),
-          or leave empty for all standard supported versions
+          or leave empty for all released versions with routine chart automation
         required: false
         default: ""
         type: string
@@ -48,8 +48,8 @@ jobs:
             echo "Using manually specified version: $MANUAL_VERSION"
             echo "versions=${MANUAL_VERSION}" >> $GITHUB_OUTPUT
           else
-            echo "Using standard supported versions from chart-versions.yaml"
-            versions=$(yq '.camundaVersions.supportStandard | join(" ")' charts/chart-versions.yaml)
+            echo "Using released routine versions from chart-versions.yaml"
+            versions=$(yq '. as $config | .chartAutomation.routineVersions | map(. as $version | select(($config.camundaSupportLifecycle[$version].released // "") != "")) | join(" ")' charts/chart-versions.yaml)
             echo "versions=${versions}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -86,18 +86,12 @@ jobs:
       #
       # Post Upgrade Tasks.
       #
-      # SUPPORTED_CHANGED = CHANGED_CHARTS minus out-of-support chart versions.
-      # The exclusion list is derived dynamically from charts/chart-versions.yaml
-      # (supportExtended + endOfLife), so updating that file is the only thing
-      # needed when a version transitions to end-of-support — no changes here.
       - name: Set vars
         run: |
           CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')
           echo "CHANGED_CHARTS=${CHANGED_CHARTS}" | tee -a $GITHUB_ENV
-          # Build exclude pattern from supportExtended + endOfLife in charts/chart-versions.yaml.
-          # Dots are escaped (8\.6 not 8.6) so the regex matches literal version strings only.
-          EXCLUDED_VERSIONS=$(yq '.camundaVersions.supportExtended + .camundaVersions.endOfLife | map(. | sub("\.", "\\.")) | join("|")' charts/chart-versions.yaml)
-          SUPPORTED_CHANGED=$(echo "${CHANGED_CHARTS}" | tr ' ' '\n' | grep -Ev "camunda-platform-(${EXCLUDED_VERSIONS})([^0-9]|$)" | tr '\n' ' ' | xargs || true)
+          ROUTINE_CHARTS=$(yq -r '.chartAutomation.routineVersions[] | "charts/camunda-platform-" + .' charts/chart-versions.yaml)
+          SUPPORTED_CHANGED=$(echo "${CHANGED_CHARTS}" | tr ' ' '\n' | grep -Fxf <(printf '%s\n' "$ROUTINE_CHARTS") | tr '\n' ' ' | xargs || true)
           echo "SUPPORTED_CHANGED=${SUPPORTED_CHANGED}" | tee -a $GITHUB_ENV
       - name: Run go mod tidy
         run: |

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -15,8 +15,6 @@ on:
         options:
           - none
           - "all"
-          - "8.4"
-          - "8.5"
           - "8.6"
           - "8.7"
           - "8.8"
@@ -78,6 +76,7 @@ on:
           - keycloak-mt
           - keycloak-original
           - keycloak-rba
+          - multitenancy
           - oidc
           - opensearch
           - shadow-e2e

--- a/charts/camunda-platform-8.6/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.6/test/ci/registry-snapshot.yaml
@@ -1,0 +1,53 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  case:
+    pr:
+      scenario:
+        - name: elasticsearch
+          enabled: false
+          shortname: es
+          auth: keycloak
+          flow: install,upgrade-patch
+          platforms:
+            - gke
+            - eks
+          exclude: []
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          skip-e2e: true
+        - name: opensearch
+          enabled: false
+          shortname: os
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: opensearch
+          skip-e2e: true
+        - name: multitenancy
+          enabled: false
+          shortname: mt
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+          skip-e2e: true
+    nightly:
+      scenario: []

--- a/charts/camunda-platform-8.6/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.6/test/ci/registry/manifest.yaml
@@ -1,0 +1,15 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  scenarios:
+    - id: elasticsearch
+      shortname: es
+      enabled: false
+    - id: opensearch
+      shortname: os
+      enabled: false
+    - id: multitenancy
+      shortname: mt
+      enabled: false

--- a/charts/camunda-platform-8.6/test/ci/registry/scenarios/elasticsearch.yaml
+++ b/charts/camunda-platform-8.6/test/ci/registry/scenarios/elasticsearch.yaml
@@ -1,0 +1,13 @@
+name: elasticsearch
+auth: keycloak
+flows:
+  - install,upgrade-patch
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+  - eks
+infra-type:
+  eks: preemptible
+  gke: distroci
+skip-e2e: true

--- a/charts/camunda-platform-8.6/test/ci/registry/scenarios/multitenancy.yaml
+++ b/charts/camunda-platform-8.6/test/ci/registry/scenarios/multitenancy.yaml
@@ -1,0 +1,13 @@
+name: multitenancy
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true

--- a/charts/camunda-platform-8.6/test/ci/registry/scenarios/opensearch.yaml
+++ b/charts/camunda-platform-8.6/test/ci/registry/scenarios/opensearch.yaml
@@ -1,0 +1,11 @@
+name: opensearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true

--- a/charts/camunda-platform-8.6/test/integration/scenarios/pre-setup-scripts/pre-install-upgrade.sh
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/pre-setup-scripts/pre-install-upgrade.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# orphan-ok: no-op placeholder for the upgrade flow; not invoked by the matrix runner.
 #
 # This script will run before the Camunda Helm chart install step in the "upgrade" flow.
 # Any necessary tasks should be performed here and removed after the release.

--- a/charts/camunda-platform-8.6/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.6/test/unit/common/notes_test.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	_ "camunda-platform/test/unit/utils"
 	"os/exec"
 	"path/filepath"
 	"strings"

--- a/charts/chart-versions.yaml
+++ b/charts/chart-versions.yaml
@@ -15,6 +15,11 @@ camundaVersions:
   supportStandard:
     - "8.9"
     - "8.8"
+    # 8.7 stays here past its stdSupportUntil to keep chart releases and CI coverage alive for
+    # extended-support cases. Moving it to supportExtended drops it from ActiveVersions (CI
+    # matrix, dev packages, release verification), excludes it from the Renovate post-upgrade
+    # chores, and renders it in the version matrix as a frozen single-chart row. Reconcile
+    # against the ESUP Case Registry at each minor chore; move it once no case needs it.
     - "8.7"
   supportExtended:
     - "8.6"

--- a/charts/chart-versions.yaml
+++ b/charts/chart-versions.yaml
@@ -1,6 +1,6 @@
 # ─── CI-internal ────────────────────────────────────────────────────────────
-# This file lists the supported Camunda chart versions and is consumed by CI,
-# release tooling, and Renovate. External users deploying Camunda 8
+# This file selects routine chart automation and records lifecycle metadata for
+# release tooling and the version matrix. External users deploying Camunda 8
 # Self-Managed do NOT need to edit it — read it via
 # `deploy-camunda matrix list` if you need to know which versions are active.
 #
@@ -9,37 +9,22 @@
 #
 # Maintainer update procedure: docs/reference/release-process.md ("Minor Version Chores").
 # ────────────────────────────────────────────────────────────────────────────
-camundaVersions:
-  alpha:
+chartAutomation:
+  routineVersions:
     - "8.10"
-  supportStandard:
     - "8.9"
     - "8.8"
-    # 8.7 stays here past its stdSupportUntil to keep chart releases and CI coverage alive for
-    # extended-support cases. Moving it to supportExtended drops it from ActiveVersions (CI
-    # matrix, dev packages, release verification), excludes it from the Renovate post-upgrade
-    # chores, and renders it in the version matrix as a frozen single-chart row. Reconcile
-    # against the ESUP Case Registry at each minor chore; move it once no case needs it.
     - "8.7"
-  supportExtended:
-    - "8.6"
-    - "8.5"
-    - "8.4"
-    - "8.3"
-  endOfLife:
-    - "8.2"
-    - "8.1"
-    - "8.0"
 
 # Per-minor support-lifecycle facts consumed by the version-matrix renderer
-# (release-tools version-matrix). Every minor listed in a camundaVersions
-# bucket needs an entry here — the renderer fails loudly otherwise.
-# Dates are ISO 8601. Field contract per bucket:
+# (release-tools version-matrix), independent of routine automation membership.
+# Dates are ISO 8601. Display groups are derived from field presence:
+#   alpha:           no released date; note optional
 #   supportStandard: released + stdSupportUntil
-#   supportExtended: released
-#   endOfLife:       released + eolSince (+ latestChart for minors whose
-#                    version-matrix.json no longer exists)
-#   alpha:           note only (optional)
+#   supportExtended: released without stdSupportUntil or eolSince
+#   endOfLife:       released + eolSince (takes precedence over stdSupportUntil)
+# latestChart supplies the last chart for minors without version-matrix.json.
+# Keep lifecycle dates when routine automation ends; GA chores populate released.
 camundaSupportLifecycle:
   # NOTE: repoint the Hub docs link from /next/ to the versioned /8.10/ path at 8.10 GA.
   "8.10":

--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -41,7 +41,7 @@ The charts are built, linted, and tested on every push to the main branch. The r
 
 **What happens:**
 
-1. Builds dev packages for all **active** chart versions (alpha + standard support).
+1. Builds dev packages for all chart versions selected by `chartAutomation.routineVersions`.
 2. Computes the release version using `release-please --dry-run`.
 3. Applies release transformations (removes dev comments, badges).
 4. Generates release notes using the `release-tools release-notes` command.
@@ -186,9 +186,9 @@ graph TD
 - `13.x` = Camunda 8.8
 - `14.x` = Camunda 8.9
 
-## Supported Versions
+## Routine Chart Automation
 
-Active chart versions are defined in [`charts/chart-versions.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/charts/chart-versions.yaml).
+`chartAutomation.routineVersions` in [`charts/chart-versions.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/charts/chart-versions.yaml) selects routine CI, dev packaging, artifact verification, and maintenance chores. Lifecycle metadata is independent and controls the existing version-matrix display. An ESUP case requires routine Helm chart automation only when its agreed delivery scope includes that maintenance; component-only cases can use explicit ad-hoc validation without joining the routine list.
 
 ## Minor Version Chores
 
@@ -210,11 +210,12 @@ Assuming `current alpha is 8.9` (which will become `stable`) and the `new alpha 
 **Configuration files updates:**
 
 1. Update [`charts/chart-versions.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/charts/chart-versions.yaml) —
-   both the `camundaVersions` buckets and the matching `camundaSupportLifecycle` entries
-   (release/support/EOL dates; the version-matrix renderer fails loudly when they diverge).
-   Before moving a minor out of `supportStandard`, reconcile it against the ESUP Case Registry:
-   a minor with an active case keeps its chart releases and CI coverage and must stay in
-   `supportStandard` (see the comment on that list in `chart-versions.yaml`).
+   set `released` and `stdSupportUntil` in `camundaSupportLifecycle` for the minor becoming GA.
+   The presence of `released` switches release tooling from prerelease to stable selection.
+   Add the new alpha's lifecycle entry without `released`, and add it to `chartAutomation.routineVersions`.
+   Reconcile routine membership against the ESUP Case Registry's Helm chart delivery scope;
+   keep a minor in the routine list while that scope requires continued chart maintenance.
+   Do not remove lifecycle dates when removing a minor from routine automation.
 2. Update Release-Please config and manifest in `.github/config/release-please/`.
 3. Update [`renovate.json5`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/renovate.json5).
 4. Update GitHub Actions with version choices (search for `type: choice`).

--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -212,6 +212,9 @@ Assuming `current alpha is 8.9` (which will become `stable`) and the `new alpha 
 1. Update [`charts/chart-versions.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/charts/chart-versions.yaml) —
    both the `camundaVersions` buckets and the matching `camundaSupportLifecycle` entries
    (release/support/EOL dates; the version-matrix renderer fails loudly when they diverge).
+   Before moving a minor out of `supportStandard`, reconcile it against the ESUP Case Registry:
+   a minor with an active case keeps its chart releases and CI coverage and must stay in
+   `supportStandard` (see the comment on that list in `chart-versions.yaml`).
 2. Update Release-Please config and manifest in `.github/config/release-please/`.
 3. Update [`renovate.json5`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/renovate.json5).
 4. Update GitHub Actions with version choices (search for `type: choice`).

--- a/scripts/camunda-core/pkg/chartmeta/package.go
+++ b/scripts/camunda-core/pkg/chartmeta/package.go
@@ -17,6 +17,8 @@ package chartmeta
 import (
 	"fmt"
 	"strings"
+
+	"scripts/camunda-core/pkg/versionmatrix"
 )
 
 // ChartImagesAnnotation is the Chart.yaml annotation holding the chart's full
@@ -51,12 +53,11 @@ type PackageMetadata struct {
 	CosignVerify      string // camunda-platform-{Version}-cosign-verify.sh
 	ImageVersions     string // camunda.io/component-image-versions annotation ("" if absent)
 	HasImageOverrides bool   // whether the camunda.io/imageOverrides annotation is present/non-empty
-	IsLatestStable    *bool  // AppVersion == chart-versions supportStandard[0]; nil when not evaluated
+	IsLatestStable    *bool  // AppVersion == newest released minor; nil when not evaluated
 }
 
 // ReadPackageMetadata parses the extracted chartYAMLPath. When chartVersionsPath
-// is non-empty it also computes IsLatestStable against
-// .camundaVersions.supportStandard[0].
+// is non-empty it also computes IsLatestStable from lifecycle release metadata.
 func ReadPackageMetadata(chartYAMLPath, chartVersionsPath string) (PackageMetadata, error) {
 	m, err := readValues(chartYAMLPath)
 	if err != nil {
@@ -88,7 +89,11 @@ func ReadPackageMetadata(chartYAMLPath, chartVersionsPath string) (PackageMetada
 		HasImageOverrides: imageOverrides != "",
 	}
 	if chartVersionsPath != "" {
-		latest, err := latestSupportStandard(chartVersionsPath)
+		versions, err := versionmatrix.LoadChartVersionsConfig(chartVersionsPath)
+		if err != nil {
+			return meta, err
+		}
+		latest, err := versions.LatestStable()
 		if err != nil {
 			return meta, err
 		}
@@ -107,20 +112,4 @@ func stripDotX(s string) string {
 		}
 	}
 	return s
-}
-
-// latestSupportStandard returns .camundaVersions.supportStandard[0] from a
-// chart-versions.yaml, the "latest stable" Camunda minor.
-func latestSupportStandard(path string) (string, error) {
-	cv, err := readValues(path)
-	if err != nil {
-		return "", fmt.Errorf("read %s: %w", path, err)
-	}
-	camundaVersions, _ := cv["camundaVersions"].(map[string]any)
-	arr, _ := camundaVersions["supportStandard"].([]any)
-	if len(arr) == 0 {
-		return "", fmt.Errorf("camundaVersions.supportStandard is empty in %s", path)
-	}
-	s, _ := scalarString(arr[0])
-	return s, nil
 }

--- a/scripts/camunda-core/pkg/chartmeta/package_test.go
+++ b/scripts/camunda-core/pkg/chartmeta/package_test.go
@@ -59,10 +59,12 @@ annotations:
     orchestration: custom
 `)
 	chartVersions := writeFile(t, dir, "chart-versions.yaml", `
-camundaVersions:
-  supportStandard:
-    - "8.10"
-    - "8.9"
+chartAutomation: { routineVersions: ["8.9"] }
+camundaSupportLifecycle: {
+"8.11": {},
+"8.10": { released: "2026-10-13", stdSupportUntil: "2028-04-12" },
+"8.9": { released: "2026-04-14", stdSupportUntil: "2027-10-13" }
+}
 `)
 	meta, err := ReadPackageMetadata(chartYAML, chartVersions)
 	if err != nil {
@@ -93,7 +95,7 @@ camundaVersions:
 		t.Error("HasImageOverrides should be true")
 	}
 	if meta.IsLatestStable == nil || !*meta.IsLatestStable {
-		t.Errorf("IsLatestStable should be true (8.10 == supportStandard[0])")
+		t.Errorf("IsLatestStable should be true (8.10 is the newest released minor)")
 	}
 }
 
@@ -106,10 +108,11 @@ annotations:
   camunda.io/component-image-versions: ""
 `)
 	chartVersions := writeFile(t, dir, "chart-versions.yaml", `
-camundaVersions:
-  supportStandard:
-    - "8.10"
-    - "8.9"
+chartAutomation: { routineVersions: ["8.9"] }
+camundaSupportLifecycle: {
+"8.10": { released: "2026-10-13", stdSupportUntil: "2028-04-12" },
+"8.9": { released: "2026-04-14", stdSupportUntil: "2027-10-13" }
+}
 `)
 	meta, err := ReadPackageMetadata(chartYAML, chartVersions)
 	if err != nil {

--- a/scripts/camunda-core/pkg/releaseplease/releaseplease.go
+++ b/scripts/camunda-core/pkg/releaseplease/releaseplease.go
@@ -21,12 +21,11 @@ package releaseplease
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"scripts/camunda-core/pkg/versionmatrix"
 )
 
 var (
@@ -50,7 +49,7 @@ type Result struct {
 // Compute derives the release version, prerelease flag and dev tag.
 //
 //   - currentVersion: Chart.yaml .version.
-//   - stillAlpha: whether chartVersion is still listed under camundaVersions.alpha
+//   - stillAlpha: whether chartVersion has no lifecycle released date
 //     (see StillAlpha) — distinguishes a prerelease bump from an alpha→stable cut.
 //   - traceLog: the release-please dry-run trace (only consulted for a stable
 //     release where the version must be scraped).
@@ -120,25 +119,14 @@ func ScrapeTraceVersion(traceLog, chartDir string) string {
 	return ""
 }
 
-// StillAlpha reports whether chartVersion is listed under
-// .camundaVersions.alpha[] in chart-versions.yaml.
+// StillAlpha reports whether chartVersion has no lifecycle released date.
 func StillAlpha(chartVersionsPath, chartVersion string) (bool, error) {
-	data, err := os.ReadFile(chartVersionsPath)
+	versions, err := versionmatrix.LoadChartVersionsConfig(chartVersionsPath)
 	if err != nil {
-		return false, fmt.Errorf("read %s: %w", chartVersionsPath, err)
+		return false, err
 	}
-	var cv struct {
-		CamundaVersions struct {
-			Alpha []string `yaml:"alpha"`
-		} `yaml:"camundaVersions"`
+	if versions.BucketOf(chartVersion) == "" {
+		return false, fmt.Errorf("minor %s has no camundaSupportLifecycle entry", chartVersion)
 	}
-	if err := yaml.Unmarshal(data, &cv); err != nil {
-		return false, fmt.Errorf("parse %s: %w", chartVersionsPath, err)
-	}
-	for _, v := range cv.CamundaVersions.Alpha {
-		if v == chartVersion {
-			return true, nil
-		}
-	}
-	return false, nil
+	return versions.BucketOf(chartVersion) == versionmatrix.BucketAlpha, nil
 }

--- a/scripts/camunda-core/pkg/releaseplease/releaseplease_test.go
+++ b/scripts/camunda-core/pkg/releaseplease/releaseplease_test.go
@@ -107,7 +107,7 @@ func TestScrapeTraceVersionGreedyStrip(t *testing.T) {
 func TestStillAlpha(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "chart-versions.yaml")
-	if err := os.WriteFile(p, []byte("camundaVersions:\n  alpha:\n    - \"8.10\"\n  supportStandard:\n    - \"8.9\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(p, []byte("chartAutomation: {routineVersions: [\"8.9\"]}\ncamundaSupportLifecycle:\n  \"8.10\": {}\n  \"8.9\": {released: \"2026-04-14\"}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	yes, err := StillAlpha(p, "8.10")
@@ -117,5 +117,8 @@ func TestStillAlpha(t *testing.T) {
 	no, err := StillAlpha(p, "8.9")
 	if err != nil || no {
 		t.Errorf("8.9 should not be alpha: %v %v", no, err)
+	}
+	if _, err := StillAlpha(p, "9.99"); err == nil {
+		t.Error("unknown minor must not be treated as a GA transition")
 	}
 }

--- a/scripts/camunda-core/pkg/versionmatrix/lifecycle.go
+++ b/scripts/camunda-core/pkg/versionmatrix/lifecycle.go
@@ -18,13 +18,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
-// Lifecycle bucket names, mirroring the camundaVersions keys in
-// charts/chart-versions.yaml.
 const (
 	BucketAlpha           = "alpha"
 	BucketSupportStandard = "supportStandard"
@@ -43,17 +42,13 @@ type Lifecycle struct {
 	Note            string `yaml:"note"`
 }
 
-// Buckets mirrors the camundaVersions block of charts/chart-versions.yaml.
-type Buckets struct {
-	Alpha           []string `yaml:"alpha"`
-	SupportStandard []string `yaml:"supportStandard"`
-	SupportExtended []string `yaml:"supportExtended"`
-	EndOfLife       []string `yaml:"endOfLife"`
+type ChartAutomation struct {
+	RoutineVersions []string `yaml:"routineVersions"`
 }
 
 // ChartVersionsConfig is the parsed charts/chart-versions.yaml.
 type ChartVersionsConfig struct {
-	CamundaVersions         Buckets              `yaml:"camundaVersions"`
+	ChartAutomation         ChartAutomation      `yaml:"chartAutomation"`
 	CamundaSupportLifecycle map[string]Lifecycle `yaml:"camundaSupportLifecycle"`
 }
 
@@ -80,75 +75,79 @@ func LoadChartVersionsConfig(path string) (*ChartVersionsConfig, error) {
 
 // BucketOf returns the bucket name a minor is classified under, or "".
 func (c *ChartVersionsConfig) BucketOf(minor string) string {
-	for bucket, minors := range map[string][]string{
-		BucketAlpha:           c.CamundaVersions.Alpha,
-		BucketSupportStandard: c.CamundaVersions.SupportStandard,
-		BucketSupportExtended: c.CamundaVersions.SupportExtended,
-		BucketEndOfLife:       c.CamundaVersions.EndOfLife,
-	} {
-		for _, m := range minors {
-			if m == minor {
-				return bucket
-			}
-		}
+	lifecycle, ok := c.CamundaSupportLifecycle[minor]
+	if !ok {
+		return ""
 	}
-	return ""
+	switch {
+	case lifecycle.EOLSince != "":
+		return BucketEndOfLife
+	case lifecycle.Released == "":
+		return BucketAlpha
+	case lifecycle.StdSupportUntil != "":
+		return BucketSupportStandard
+	default:
+		return BucketSupportExtended
+	}
 }
 
-// AllMinors returns every minor listed in any bucket, in bucket order
-// (alpha, supportStandard, supportExtended, endOfLife).
 func (c *ChartVersionsConfig) AllMinors() []string {
-	var all []string
-	all = append(all, c.CamundaVersions.Alpha...)
-	all = append(all, c.CamundaVersions.SupportStandard...)
-	all = append(all, c.CamundaVersions.SupportExtended...)
-	all = append(all, c.CamundaVersions.EndOfLife...)
-	return all
+	minors := make([]string, 0, len(c.CamundaSupportLifecycle))
+	for minor := range c.CamundaSupportLifecycle {
+		minors = append(minors, minor)
+	}
+	return SortAppVersionsDescending(minors)
 }
 
-// Validate enforces the bucket ⟷ lifecycle contract:
-//
-//   - every minor in a bucket has a camundaSupportLifecycle entry;
-//   - every camundaSupportLifecycle key is classified in exactly one bucket;
-//   - supportStandard entries carry stdSupportUntil;
-//   - endOfLife entries carry eolSince;
-//   - supportStandard, supportExtended, and endOfLife entries carry released.
-//
-// Violations fail loudly so a lifecycle change cannot silently drop a minor
-// from the rendered matrix.
+func (c *ChartVersionsConfig) MinorsInBucket(bucket string) []string {
+	var minors []string
+	for _, minor := range c.AllMinors() {
+		if c.BucketOf(minor) == bucket {
+			minors = append(minors, minor)
+		}
+	}
+	return minors
+}
+
+func (c *ChartVersionsConfig) ActiveVersions() []string {
+	return slices.Clone(c.ChartAutomation.RoutineVersions)
+}
+
+func (c *ChartVersionsConfig) LatestStable() (string, error) {
+	for _, minor := range c.AllMinors() {
+		if c.CamundaSupportLifecycle[minor].Released != "" {
+			return minor, nil
+		}
+	}
+	return "", fmt.Errorf("camundaSupportLifecycle contains no released minor")
+}
+
 func (c *ChartVersionsConfig) Validate() error {
-	seen := map[string]int{}
-	for _, m := range c.AllMinors() {
-		seen[m]++
-	}
 	var errs []string
-	for m, n := range seen {
-		if n > 1 {
-			errs = append(errs, fmt.Sprintf("minor %s is listed in %d buckets", m, n))
+	if c.ChartAutomation.RoutineVersions == nil {
+		errs = append(errs, "chartAutomation.routineVersions is required (use [] to disable routine automation)")
+	}
+	if len(c.CamundaSupportLifecycle) == 0 {
+		errs = append(errs, "camundaSupportLifecycle must not be empty")
+	}
+	seen := map[string]bool{}
+	for _, minor := range c.ChartAutomation.RoutineVersions {
+		if seen[minor] {
+			errs = append(errs, fmt.Sprintf("minor %s is repeated in chartAutomation.routineVersions", minor))
+		}
+		seen[minor] = true
+		if _, ok := c.CamundaSupportLifecycle[minor]; !ok {
+			errs = append(errs, fmt.Sprintf("minor %s has no camundaSupportLifecycle entry", minor))
+		} else if c.BucketOf(minor) == BucketEndOfLife {
+			errs = append(errs, fmt.Sprintf("end-of-life minor %s cannot have routine automation", minor))
 		}
 	}
-	for _, m := range c.AllMinors() {
-		lc, ok := c.CamundaSupportLifecycle[m]
-		if !ok {
-			errs = append(errs, fmt.Sprintf("minor %s has no camundaSupportLifecycle entry", m))
-			continue
+	for _, minor := range c.AllMinors() {
+		lifecycle := c.CamundaSupportLifecycle[minor]
+		if lifecycle.Released == "" && (lifecycle.StdSupportUntil != "" || lifecycle.EOLSince != "" || lifecycle.LatestChart != "") {
+			errs = append(errs, fmt.Sprintf("minor %s has release metadata but is missing released", minor))
 		}
-		bucket := c.BucketOf(m)
-		if bucket != BucketAlpha && lc.Released == "" {
-			errs = append(errs, fmt.Sprintf("minor %s (%s) is missing released", m, bucket))
-		}
-		if bucket == BucketSupportStandard && lc.StdSupportUntil == "" {
-			errs = append(errs, fmt.Sprintf("minor %s (supportStandard) is missing stdSupportUntil", m))
-		}
-		if bucket == BucketEndOfLife && lc.EOLSince == "" {
-			errs = append(errs, fmt.Sprintf("minor %s (endOfLife) is missing eolSince", m))
-		}
-		errs = append(errs, lc.validateDates(m)...)
-	}
-	for m := range c.CamundaSupportLifecycle {
-		if _, ok := seen[m]; !ok {
-			errs = append(errs, fmt.Sprintf("camundaSupportLifecycle entry %s is not in any camundaVersions bucket", m))
-		}
+		errs = append(errs, lifecycle.validateDates(minor)...)
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("chart-versions lifecycle validation failed:\n  - %s", joinLines(errs))

--- a/scripts/camunda-core/pkg/versionmatrix/lifecycle.go
+++ b/scripts/camunda-core/pkg/versionmatrix/lifecycle.go
@@ -15,6 +15,7 @@
 package versionmatrix
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,7 +65,9 @@ func LoadChartVersionsConfig(path string) (*ChartVersionsConfig, error) {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 	var cfg ChartVersionsConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 	if err := cfg.Validate(); err != nil {
@@ -124,8 +127,8 @@ func (c *ChartVersionsConfig) LatestStable() (string, error) {
 
 func (c *ChartVersionsConfig) Validate() error {
 	var errs []string
-	if c.ChartAutomation.RoutineVersions == nil {
-		errs = append(errs, "chartAutomation.routineVersions is required (use [] to disable routine automation)")
+	if len(c.ChartAutomation.RoutineVersions) == 0 {
+		errs = append(errs, "chartAutomation.routineVersions must not be empty")
 	}
 	if len(c.CamundaSupportLifecycle) == 0 {
 		errs = append(errs, "camundaSupportLifecycle must not be empty")

--- a/scripts/camunda-core/pkg/versionmatrix/lifecycle_test.go
+++ b/scripts/camunda-core/pkg/versionmatrix/lifecycle_test.go
@@ -17,21 +17,14 @@ package versionmatrix
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
 
 func validYAML() string {
 	return `
-camundaVersions:
-  alpha:
-    - "8.10"
-  supportStandard:
-    - "8.9"
-  supportExtended:
-    - "8.6"
-  endOfLife:
-    - "8.2"
+chartAutomation: { routineVersions: ["8.10", "8.9"] }
 camundaSupportLifecycle:
   "8.10": { note: "hub pointer" }
   "8.9":  { released: "2026-04-14", stdSupportUntil: "2027-10-13" }
@@ -69,42 +62,110 @@ func TestLoadChartVersionsConfigValid(t *testing.T) {
 	}
 }
 
+func TestRoutineAutomationIndependentOfLifecycle(t *testing.T) {
+	t.Parallel()
+	cfg, err := loadFromString(t, `
+chartAutomation:
+  routineVersions: ["8.10", "8.9", "8.7"]
+camundaSupportLifecycle:
+  "8.10": { note: "preview" }
+  "8.9": { released: "2026-04-14", stdSupportUntil: "2027-10-13" }
+  "8.7": { released: "2025-04-08", stdSupportUntil: "2026-10-13" }
+  "8.6": { released: "2024-10-08" }
+  "8.2": { released: "2022-10-11", eolSince: "2024-10-08", latestChart: "8.2.34" }
+`)
+	if err != nil {
+		t.Fatalf("LoadChartVersionsConfig: %v", err)
+	}
+	if got := cfg.ActiveVersions(); !slices.Equal(got, []string{"8.10", "8.9", "8.7"}) {
+		t.Fatalf("ActiveVersions = %v", got)
+	}
+	for minor, want := range map[string]string{
+		"8.10": BucketAlpha,
+		"8.9":  BucketSupportStandard,
+		"8.7":  BucketSupportStandard,
+		"8.6":  BucketSupportExtended,
+		"8.2":  BucketEndOfLife,
+	} {
+		if got := cfg.BucketOf(minor); got != want {
+			t.Errorf("BucketOf(%s) = %q, want %q", minor, got, want)
+		}
+	}
+	before, err := RenderIndex(cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.ChartAutomation.RoutineVersions = []string{"8.6"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := RenderIndex(cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before != after {
+		t.Error("routine automation membership changed the rendered version matrix")
+	}
+}
+
+func TestLifecycleReleaseSelection(t *testing.T) {
+	t.Parallel()
+	cfg, err := loadFromString(t, validYAML())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.ChartAutomation.RoutineVersions = []string{"8.6"}
+	if latest, err := cfg.LatestStable(); err != nil || latest != "8.9" {
+		t.Fatalf("LatestStable = %q, %v; want 8.9", latest, err)
+	}
+	cfg.CamundaSupportLifecycle["8.10"] = Lifecycle{Released: "2026-10-13", StdSupportUntil: "2028-04-12"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if latest, err := cfg.LatestStable(); err != nil || latest != "8.10" {
+		t.Fatalf("LatestStable after GA = %q, %v; want 8.10", latest, err)
+	}
+	if got := cfg.BucketOf("8.10"); got != BucketSupportStandard {
+		t.Errorf("BucketOf(8.10) after GA = %q", got)
+	}
+	cfg.ChartAutomation.RoutineVersions = []string{}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("empty routine list: %v", err)
+	}
+}
+
 func TestValidateFailures(t *testing.T) {
 	cases := map[string]struct {
 		mutate string
 		want   string
 	}{
-		"bucket minor without lifecycle entry": {
-			mutate: strings.Replace(validYAML(), `  "8.6":  { released: "2024-10-08" }`+"\n", "", 1),
-			want:   "8.6 has no camundaSupportLifecycle entry",
+		"routine minor without lifecycle entry": {
+			mutate: strings.Replace(validYAML(), `  "8.9":  { released: "2026-04-14", stdSupportUntil: "2027-10-13" }`+"\n", "", 1),
+			want:   "8.9 has no camundaSupportLifecycle entry",
 		},
-		"lifecycle entry without bucket": {
-			mutate: validYAML() + `  "7.9": { released: "2020-01-01" }` + "\n",
-			want:   "7.9 is not in any camundaVersions bucket",
+		"missing routine list": {
+			mutate: strings.Replace(validYAML(), `chartAutomation: { routineVersions: ["8.10", "8.9"] }`, `chartAutomation: {}`, 1),
+			want:   "chartAutomation.routineVersions is required",
 		},
-		"supportStandard missing stdSupportUntil": {
+		"support metadata missing released": {
 			mutate: strings.Replace(validYAML(),
 				`"8.9":  { released: "2026-04-14", stdSupportUntil: "2027-10-13" }`,
-				`"8.9":  { released: "2026-04-14" }`, 1),
-			want: "8.9 (supportStandard) is missing stdSupportUntil",
+				`"8.9":  { stdSupportUntil: "2027-10-13" }`, 1),
+			want: "8.9 has release metadata but is missing released",
 		},
-		"endOfLife missing eolSince": {
+		"eol metadata missing released": {
 			mutate: strings.Replace(validYAML(),
 				`"8.2":  { released: "2022-10-11", eolSince: "2024-10-08", latestChart: "8.2.34" }`,
-				`"8.2":  { released: "2022-10-11" }`, 1),
-			want: "8.2 (endOfLife) is missing eolSince",
+				`"8.2":  { eolSince: "2024-10-08", latestChart: "8.2.34" }`, 1),
+			want: "8.2 has release metadata but is missing released",
 		},
-		"non-alpha missing released": {
-			mutate: strings.Replace(validYAML(),
-				`"8.6":  { released: "2024-10-08" }`,
-				`"8.6":  { note: "x" }`, 1),
-			want: "8.6 (supportExtended) is missing released",
+		"eol routine minor": {
+			mutate: strings.Replace(validYAML(), `["8.10", "8.9"]`, `["8.10", "8.9", "8.2"]`, 1),
+			want:   "end-of-life minor 8.2 cannot have routine automation",
 		},
-		"minor in two buckets": {
-			mutate: strings.Replace(validYAML(),
-				"  supportExtended:\n    - \"8.6\"",
-				"  supportExtended:\n    - \"8.6\"\n    - \"8.9\"", 1),
-			want: "8.9 is listed in 2 buckets",
+		"duplicate routine minor": {
+			mutate: strings.Replace(validYAML(), `["8.10", "8.9"]`, `["8.10", "8.9", "8.9"]`, 1),
+			want:   "8.9 is repeated in chartAutomation.routineVersions",
 		},
 	}
 	for name, tc := range cases {

--- a/scripts/camunda-core/pkg/versionmatrix/lifecycle_test.go
+++ b/scripts/camunda-core/pkg/versionmatrix/lifecycle_test.go
@@ -62,6 +62,34 @@ func TestLoadChartVersionsConfigValid(t *testing.T) {
 	}
 }
 
+func TestLoadChartVersionsConfigRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		field string
+		typo  string
+	}{
+		{field: "chartAutomation", typo: "chartAutomaton"},
+		{field: "routineVersions", typo: "routineVersion"},
+		{field: "released", typo: "relesaed"},
+		{field: "stdSupportUntil", typo: "stdSupportUntill"},
+		{field: "eolSince", typo: "eolSicne"},
+	} {
+		t.Run(testCase.field, func(t *testing.T) {
+			content := strings.Replace(validYAML(), testCase.field+":", testCase.typo+":", 1)
+			cfg, err := loadFromString(t, content)
+			if err == nil {
+				t.Fatal("expected unknown field to fail decoding")
+			}
+			if want := "field " + testCase.typo + " not found"; !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not contain %q", err, want)
+			}
+			if cfg != nil {
+				t.Error("invalid YAML returned a usable configuration")
+			}
+		})
+	}
+}
+
 func TestRoutineAutomationIndependentOfLifecycle(t *testing.T) {
 	t.Parallel()
 	cfg, err := loadFromString(t, `
@@ -128,10 +156,6 @@ func TestLifecycleReleaseSelection(t *testing.T) {
 	if got := cfg.BucketOf("8.10"); got != BucketSupportStandard {
 		t.Errorf("BucketOf(8.10) after GA = %q", got)
 	}
-	cfg.ChartAutomation.RoutineVersions = []string{}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("empty routine list: %v", err)
-	}
 }
 
 func TestValidateFailures(t *testing.T) {
@@ -145,7 +169,15 @@ func TestValidateFailures(t *testing.T) {
 		},
 		"missing routine list": {
 			mutate: strings.Replace(validYAML(), `chartAutomation: { routineVersions: ["8.10", "8.9"] }`, `chartAutomation: {}`, 1),
-			want:   "chartAutomation.routineVersions is required",
+			want:   "chartAutomation.routineVersions must not be empty",
+		},
+		"empty routine list": {
+			mutate: strings.Replace(validYAML(), `["8.10", "8.9"]`, `[]`, 1),
+			want:   "chartAutomation.routineVersions must not be empty",
+		},
+		"null routine list": {
+			mutate: strings.Replace(validYAML(), `["8.10", "8.9"]`, `null`, 1),
+			want:   "chartAutomation.routineVersions must not be empty",
 		},
 		"support metadata missing released": {
 			mutate: strings.Replace(validYAML(),

--- a/scripts/camunda-core/pkg/versionmatrix/readme.go
+++ b/scripts/camunda-core/pkg/versionmatrix/readme.go
@@ -210,7 +210,7 @@ func latestChartCell(app string, entries []ChartEntry, lc Lifecycle) string {
 }
 
 // RenderIndex renders the top-level version-matrix/README.md: one section per
-// active minor (alpha + supportStandard, newest first) with its
+// active minor (derived from lifecycle metadata, newest first) with its
 // indexTableLimit newest chart versions and a link to the full per-minor
 // matrix, then one compact table each for extended-support and end-of-life
 // minors. entriesByApp values must be sorted newest-first.
@@ -218,7 +218,7 @@ func RenderIndex(cfg *ChartVersionsConfig, entriesByApp map[string][]ChartEntry)
 	var b strings.Builder
 	b.WriteString(indexHeader)
 
-	active := append(append([]string{}, cfg.CamundaVersions.Alpha...), cfg.CamundaVersions.SupportStandard...)
+	active := append(cfg.MinorsInBucket(BucketAlpha), cfg.MinorsInBucket(BucketSupportStandard)...)
 	supportNotePending := true
 	for _, app := range SortAppVersionsDescending(active) {
 		lc := cfg.CamundaSupportLifecycle[app]
@@ -245,7 +245,7 @@ func RenderIndex(cfg *ChartVersionsConfig, entriesByApp map[string][]ChartEntry)
 		fmt.Fprintf(&b, "\n[All %d chart versions for Camunda %s →](./camunda-%s/)\n", len(entries), app, app)
 	}
 
-	if minors := cfg.CamundaVersions.SupportExtended; len(minors) > 0 {
+	if minors := cfg.MinorsInBucket(BucketSupportExtended); len(minors) > 0 {
 		b.WriteString("\n## Extended support\n\n")
 		b.WriteString("| Camunda | Released | Latest chart | Full matrix |\n|---|---|---|---|\n")
 		for _, app := range SortAppVersionsDescending(minors) {
@@ -255,7 +255,7 @@ func RenderIndex(cfg *ChartVersionsConfig, entriesByApp map[string][]ChartEntry)
 		}
 	}
 
-	if minors := cfg.CamundaVersions.EndOfLife; len(minors) > 0 {
+	if minors := cfg.MinorsInBucket(BucketEndOfLife); len(minors) > 0 {
 		b.WriteString("\n## End of life — no longer supported\n\n")
 		b.WriteString("| Camunda | EOL since | Last chart | Full matrix |\n|---|---|---|---|\n")
 		for _, app := range SortAppVersionsDescending(minors) {

--- a/scripts/camunda-core/pkg/versionmatrix/readme_test.go
+++ b/scripts/camunda-core/pkg/versionmatrix/readme_test.go
@@ -196,12 +196,7 @@ func TestChartTableRowMissingFacts(t *testing.T) {
 // testConfig builds a ChartVersionsConfig covering all four buckets.
 func testConfig() *ChartVersionsConfig {
 	return &ChartVersionsConfig{
-		CamundaVersions: Buckets{
-			Alpha:           []string{"8.10"},
-			SupportStandard: []string{"8.9", "8.8"},
-			SupportExtended: []string{"8.6"},
-			EndOfLife:       []string{"8.2"},
-		},
+		ChartAutomation: ChartAutomation{RoutineVersions: []string{"8.10", "8.9", "8.8"}},
 		CamundaSupportLifecycle: map[string]Lifecycle{
 			"8.10": {Note: "Deploys Camunda Hub — see the [Hub documentation](https://example.invalid/hub)."},
 			"8.9":  {Released: "2026-04-14", StdSupportUntil: "2027-10-13"},

--- a/scripts/check-values-latest.sh
+++ b/scripts/check-values-latest.sh
@@ -205,7 +205,7 @@ main() {
     else
         while IFS= read -r version; do
             charts+=("camunda-platform-${version}")
-        done < <(yq eval -r '.camundaVersions.alpha[], .camundaVersions.supportStandard[]' "${REPO_ROOT}/charts/chart-versions.yaml")
+        done < <(yq eval -r '.chartAutomation.routineVersions[]' "${REPO_ROOT}/charts/chart-versions.yaml")
     fi
     
     # Validate each chart

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -544,14 +544,27 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				return err
 			}
 
-			entries = matrix.Filter(entries, matrix.FilterOptions{
+			filterOptions := matrix.FilterOptions{
 				ScenarioFilter:  scenarioFilter,
 				ShortnameFilter: shortnameFilter,
 				ShortnameExact:  shortnameExact,
 				FlowFilter:      flowFilter,
 				Platform:        platform,
 				Tier:            tier,
-			})
+			}
+			entries = matrix.Filter(entries, filterOptions)
+			if len(entries) == 0 && !includeDisabled {
+				withDisabled, err := matrix.Generate(repoRoot, matrix.GenerateOptions{
+					Versions:        versions,
+					IncludeDisabled: true,
+				})
+				if err != nil {
+					return err
+				}
+				if matches := matrix.Filter(withDisabled, filterOptions); len(matches) > 0 {
+					return fmt.Errorf("no enabled matrix entries matched the filters (versions=%v); matching scenarios are disabled; re-run with --include-disabled to include them", versions)
+				}
+			}
 
 			// Entries whose scenario declares a topology (multi-namespace
 			// deployment) fan out to N releases and are driven directly via

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -165,7 +165,7 @@ func newMatrixListCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List the CI test matrix for all active chart versions",
+		Short: "List the CI test matrix for routine chart versions",
 		Long: `List the full CI test matrix generated from chart-versions.yaml,
 ci-test-config.yaml (PR scenarios only), and permitted-flows.yaml.
 
@@ -950,7 +950,7 @@ func registerMatrixShortnameCompletion(cmd *cobra.Command) {
 }
 
 // registerMatrixVersionsCompletion adds tab completion for the --versions flag.
-// It reads chart-versions.yaml and offers active versions (alpha + supportStandard).
+// It reads chart-versions.yaml and offers versions selected for routine automation.
 func registerMatrixVersionsCompletion(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc("versions", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		repoRoot, _ := cmd.Flags().GetString("repo-root")

--- a/scripts/deploy-camunda/cmd/matrix_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_test.go
@@ -15,6 +15,9 @@
 package cmd
 
 import (
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -39,6 +42,60 @@ func TestMatrixRunExtraValuesFlag(t *testing.T) {
 	}
 	if got := flag.Value.String(); !strings.Contains(got, "/tmp/a.yaml") || !strings.Contains(got, "/tmp/b.yaml") {
 		t.Errorf("aggregated value %q missing entries", got)
+	}
+}
+
+func TestMatrixRunDisabledScenarioHint(t *testing.T) {
+	repoRoot, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousConfigFile := configFile
+	configFile = filepath.Join(t.TempDir(), "absent.yaml")
+	t.Cleanup(func() { configFile = previousConfigFile })
+
+	for _, testCase := range []struct {
+		name    string
+		version string
+		args    []string
+		wantErr string
+	}{
+		{name: "explicit version without opt-in", version: "8.6", wantErr: "matching scenarios are disabled; re-run with --include-disabled"},
+		{name: "matching filtered entry", version: "8.6", args: []string{"--shortname-filter", "es", "--shortname-exact", "--flow-filter", "install", "--platform", "gke"}, wantErr: "matching scenarios are disabled; re-run with --include-disabled"},
+		{name: "unknown shortname", version: "8.6", args: []string{"--shortname-filter", "missing"}, wantErr: "no matrix entries matched the filters"},
+		{name: "unknown scenario", version: "8.6", args: []string{"--scenario-filter", "missing"}, wantErr: "no matrix entries matched the filters"},
+		{name: "denied flow", version: "8.6", args: []string{"--flow-filter", "upgrade-minor"}, wantErr: "no matrix entries matched the filters"},
+		{name: "unsupported platform", version: "8.6", args: []string{"--shortname-filter", "es", "--platform", "rosa"}, wantErr: "no matrix entries matched the filters"},
+		{name: "opt-in with unmatched filter", version: "8.6", args: []string{"--include-disabled", "--shortname-filter", "missing"}, wantErr: "no matrix entries matched the filters"},
+		{name: "opt-in succeeds", version: "8.6", args: []string{"--include-disabled", "--shortname-filter", "es", "--shortname-exact", "--flow-filter", "install", "--platform", "gke"}},
+		{name: "enabled selection succeeds", version: "8.9", args: []string{"--shortname-filter", "eske", "--shortname-exact", "--flow-filter", "install", "--platform", "gke"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			command := newMatrixRunCommand()
+			command.SilenceErrors = true
+			command.SilenceUsage = true
+			command.SetOut(io.Discard)
+			command.SetErr(io.Discard)
+			command.SetArgs(append([]string{
+				"--repo-root", repoRoot,
+				"--env-file", os.DevNull,
+				"--versions", testCase.version,
+				"--coverage",
+			}, testCase.args...))
+			err := command.Execute()
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("error = %v, want %q", err, testCase.wantErr)
+			}
+			if !strings.Contains(testCase.wantErr, "--include-disabled") && strings.Contains(err.Error(), "--include-disabled") {
+				t.Errorf("unmatched filters produced misleading opt-in hint: %v", err)
+			}
+		})
 	}
 }
 

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -22,38 +22,15 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+	"scripts/camunda-core/pkg/versionmatrix"
 )
 
 // ChartVersions holds the parsed content of charts/chart-versions.yaml.
-type ChartVersions struct {
-	CamundaVersions struct {
-		Alpha           []string `yaml:"alpha"`
-		SupportStandard []string `yaml:"supportStandard"`
-		SupportExtended []string `yaml:"supportExtended"`
-		EndOfLife       []string `yaml:"endOfLife"`
-	} `yaml:"camundaVersions"`
-}
-
-// ActiveVersions returns the list of active versions (alpha + supportStandard).
-func (cv *ChartVersions) ActiveVersions() []string {
-	var versions []string
-	versions = append(versions, cv.CamundaVersions.Alpha...)
-	versions = append(versions, cv.CamundaVersions.SupportStandard...)
-	return versions
-}
+type ChartVersions = versionmatrix.ChartVersionsConfig
 
 // LoadChartVersions reads and parses charts/chart-versions.yaml from the repo root.
 func LoadChartVersions(repoRoot string) (*ChartVersions, error) {
-	path := filepath.Join(repoRoot, "charts", "chart-versions.yaml")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read chart-versions.yaml: %w", err)
-	}
-	var cv ChartVersions
-	if err := yaml.Unmarshal(data, &cv); err != nil {
-		return nil, fmt.Errorf("failed to parse chart-versions.yaml: %w", err)
-	}
-	return &cv, nil
+	return versionmatrix.LoadChartVersionsConfig(versionmatrix.ChartVersionsPath(repoRoot))
 }
 
 // CITestConfig holds the parsed content of a ci-test-config.yaml file.

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jwalton/gchalk"
 
 	"scripts/camunda-core/pkg/logging"
+	"scripts/camunda-core/pkg/versionmatrix"
 )
 
 // Entry represents a single matrix entry — one scenario + one flow + one platform combination.
@@ -147,13 +148,9 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 		for _, v := range activeVersions {
 			activeSet[v] = true
 		}
-		eolSet := make(map[string]bool)
-		for _, v := range cv.CamundaVersions.EndOfLife {
-			eolSet[v] = true
-		}
 		for _, v := range opts.Versions {
 			if !activeSet[v] {
-				if eolSet[v] {
+				if cv.BucketOf(v) == versionmatrix.BucketEndOfLife {
 					return nil, fmt.Errorf("requested version %q is end-of-life and cannot be tested; active versions: %v", v, activeVersions)
 				}
 				chartDir := filepath.Join(repoRoot, "charts", "camunda-platform-"+v)

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -143,14 +143,28 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 	activeVersions := cv.ActiveVersions()
 	var versions []string
 	if len(opts.Versions) > 0 {
-		// Validate requested versions are active
 		activeSet := make(map[string]bool)
 		for _, v := range activeVersions {
 			activeSet[v] = true
 		}
+		eolSet := make(map[string]bool)
+		for _, v := range cv.CamundaVersions.EndOfLife {
+			eolSet[v] = true
+		}
 		for _, v := range opts.Versions {
 			if !activeSet[v] {
-				return nil, fmt.Errorf("requested version %q is not active (active: %v)", v, activeVersions)
+				if eolSet[v] {
+					return nil, fmt.Errorf("requested version %q is end-of-life and cannot be tested; active versions: %v", v, activeVersions)
+				}
+				chartDir := filepath.Join(repoRoot, "charts", "camunda-platform-"+v)
+				if !HasRegistry(chartDir) {
+					return nil, fmt.Errorf(
+						"requested version %q is not active and has no CI scenario registry at %s;"+
+							" active versions: %v."+
+							" Deploy a single scenario directly instead:"+
+							" deploy-camunda --scenario charts/camunda-platform-%s/test/integration/scenarios/chart-full-setup",
+						v, filepath.Join(chartDir, "test", RegistryDirName, "manifest.yaml"), activeVersions, v)
+				}
 			}
 			versions = append(versions, v)
 		}

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -738,7 +738,7 @@ func extendedVersionByRegistry(t *testing.T, repoRoot string, hasRegistry bool) 
 	if err != nil {
 		t.Fatalf("LoadChartVersions: %v", err)
 	}
-	for _, v := range cv.CamundaVersions.SupportExtended {
+	for _, v := range cv.MinorsInBucket(versionmatrix.BucketSupportExtended) {
 		chartDir := filepath.Join(repoRoot, "charts", "camunda-platform-"+v)
 		if _, statErr := os.Stat(chartDir); statErr != nil {
 			continue
@@ -803,10 +803,11 @@ func TestGenerateEndOfLifeVersionRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadChartVersions: %v", err)
 	}
-	if len(cv.CamundaVersions.EndOfLife) == 0 {
+	eolVersions := cv.MinorsInBucket(versionmatrix.BucketEndOfLife)
+	if len(eolVersions) == 0 {
 		t.Skip("no endOfLife versions in chart-versions.yaml")
 	}
-	version := cv.CamundaVersions.EndOfLife[0]
+	version := eolVersions[0]
 
 	_, err = Generate(repoRoot, GenerateOptions{Versions: []string{version}})
 	if err == nil {
@@ -832,14 +833,7 @@ func TestLoadChartVersions(t *testing.T) {
 		t.Fatal("LoadChartVersions: no active versions")
 	}
 
-	// 8.10 should be alpha
-	found := false
-	for _, v := range cv.CamundaVersions.Alpha {
-		if v == "8.10" {
-			found = true
-		}
-	}
-	if !found {
+	if cv.BucketOf("8.10") != versionmatrix.BucketAlpha {
 		t.Error("LoadChartVersions: 8.10 not found in alpha")
 	}
 }

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -629,6 +630,190 @@ func TestGenerateInvalidVersion(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("Generate(versions=99.99): expected error for invalid version")
+	}
+}
+
+func TestGenerate86RegistryContract(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	const version = "8.6"
+
+	chartDir := filepath.Join(repoRoot, "charts", "camunda-platform-"+version)
+	manifest := filepath.Join(chartDir, "test", RegistryDirName, "manifest.yaml")
+	if !HasRegistry(chartDir) {
+		t.Fatalf("chart %s has no CI scenario registry at %s: it is the only supported opt-in path for "+
+			"validating an extended-support %s chart through the matrix engine (issue #7039). "+
+			"Without it, matrix run against %s produces an empty matrix.",
+			version, manifest, version, version)
+	}
+
+	defaultEntries, err := Generate(repoRoot, GenerateOptions{Versions: []string{version}})
+	if err != nil {
+		t.Fatalf("Generate(versions=%s): %v", version, err)
+	}
+	if len(defaultEntries) != 0 {
+		t.Errorf("Generate(versions=%s): got %d entries, want 0: every %s scenario must stay enabled: false "+
+			"so the version is reachable only via --include-disabled",
+			version, len(defaultEntries), version)
+	}
+
+	wholeMatrix, err := Generate(repoRoot, GenerateOptions{})
+	if err != nil {
+		t.Fatalf("Generate(default matrix): %v", err)
+	}
+	for _, e := range wholeMatrix {
+		if e.Version == version {
+			t.Errorf("Generate(default matrix): %s scenario %q leaked into the default matrix", version, e.Scenario)
+		}
+	}
+
+	entries, err := Generate(repoRoot, GenerateOptions{
+		Versions:        []string{version},
+		IncludeDisabled: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate(versions=%s, includeDisabled): %v", version, err)
+	}
+
+	type key struct{ shortname, flow, platform string }
+	want := map[key]string{
+		{"es", "install", "gke"}:       "elasticsearch",
+		{"es", "install", "eks"}:       "elasticsearch",
+		{"es", "upgrade-patch", "gke"}: "elasticsearch",
+		{"es", "upgrade-patch", "eks"}: "elasticsearch",
+		{"os", "install", "gke"}:       "opensearch",
+		{"mt", "install", "gke"}:       "multitenancy",
+	}
+
+	got := map[key]Entry{}
+	for _, e := range entries {
+		k := key{e.Shortname, e.Flow, e.Platform}
+		if prev, dup := got[k]; dup {
+			t.Errorf("%s: duplicate entry for %+v (scenarios %q and %q)", version, k, prev.Scenario, e.Scenario)
+		}
+		got[k] = e
+	}
+
+	for k, scenario := range want {
+		e, ok := got[k]
+		if !ok {
+			t.Errorf("%s: missing entry %+v (scenario %q)", version, k, scenario)
+			continue
+		}
+		if e.Scenario != scenario {
+			t.Errorf("%s %+v: scenario = %q, want %q", version, k, e.Scenario, scenario)
+		}
+		if !e.SkipE2E {
+			t.Errorf("%s %+v: skip-e2e = false, want true: the cross-component e2e suite ships no SM-%s fixtures",
+				version, k, version)
+		}
+		if e.Enabled {
+			t.Errorf("%s %+v: enabled = true, want false", version, k)
+		}
+	}
+	for k, e := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("%s: unexpected entry %+v (scenario %q); update this contract deliberately", version, k, e.Scenario)
+		}
+	}
+
+	for k, e := range got {
+		if k.shortname != "es" {
+			continue
+		}
+		if e.Identity != "keycloak" {
+			t.Errorf("%s %+v: identity = %q, want keycloak", version, k, e.Identity)
+		}
+		if e.Persistence != "elasticsearch" {
+			t.Errorf("%s %+v: persistence = %q, want elasticsearch", version, k, e.Persistence)
+		}
+	}
+	if e, ok := got[key{"mt", "install", "gke"}]; ok && !slices.Contains(e.Features, "multitenancy") {
+		t.Errorf("%s mt: features = %v, want multitenancy", version, e.Features)
+	}
+}
+
+func extendedVersionByRegistry(t *testing.T, repoRoot string, hasRegistry bool) string {
+	t.Helper()
+	cv, err := LoadChartVersions(repoRoot)
+	if err != nil {
+		t.Fatalf("LoadChartVersions: %v", err)
+	}
+	for _, v := range cv.CamundaVersions.SupportExtended {
+		chartDir := filepath.Join(repoRoot, "charts", "camunda-platform-"+v)
+		if _, statErr := os.Stat(chartDir); statErr != nil {
+			continue
+		}
+		if HasRegistry(chartDir) == hasRegistry {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestGenerateNonActiveVersionWithRegistry(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	version := extendedVersionByRegistry(t, repoRoot, true)
+	if version == "" {
+		t.Skip("no supportExtended version has a CI scenario registry")
+	}
+
+	if _, err := Generate(repoRoot, GenerateOptions{Versions: []string{version}}); err != nil {
+		t.Fatalf("Generate(versions=%s): %v", version, err)
+	}
+
+	entries, err := Generate(repoRoot, GenerateOptions{
+		Versions:        []string{version},
+		IncludeDisabled: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate(versions=%s, includeDisabled): %v", version, err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("Generate(versions=%s, includeDisabled): got 0 entries, want the registry's scenarios", version)
+	}
+	for _, e := range entries {
+		if e.Version != version {
+			t.Errorf("Generate(versions=%s): unexpected version %s", version, e.Version)
+		}
+	}
+}
+
+func TestGenerateNonActiveVersionWithoutRegistryRejected(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	version := extendedVersionByRegistry(t, repoRoot, false)
+	if version == "" {
+		t.Skip("every supportExtended version with a chart dir has a CI scenario registry")
+	}
+
+	_, err := Generate(repoRoot, GenerateOptions{Versions: []string{version}})
+	if err == nil {
+		t.Fatalf("Generate(versions=%s): expected an error for a registry-less version, got nil", version)
+	}
+	if !strings.Contains(err.Error(), "no CI scenario registry") {
+		t.Errorf("Generate(versions=%s): error %q does not name the missing registry", version, err)
+	}
+}
+
+func TestGenerateEndOfLifeVersionRejected(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	cv, err := LoadChartVersions(repoRoot)
+	if err != nil {
+		t.Fatalf("LoadChartVersions: %v", err)
+	}
+	if len(cv.CamundaVersions.EndOfLife) == 0 {
+		t.Skip("no endOfLife versions in chart-versions.yaml")
+	}
+	version := cv.CamundaVersions.EndOfLife[0]
+
+	_, err = Generate(repoRoot, GenerateOptions{Versions: []string{version}})
+	if err == nil {
+		t.Fatalf("Generate(versions=%s): expected an error for an end-of-life version, got nil", version)
+	}
+	if !strings.Contains(err.Error(), "end-of-life") {
+		t.Errorf("Generate(versions=%s): error %q does not name end-of-life", version, err)
 	}
 }
 

--- a/scripts/deploy-camunda/matrix/plan.go
+++ b/scripts/deploy-camunda/matrix/plan.go
@@ -28,8 +28,7 @@ import (
 // PlanOptions carries the inputs of the generate-chart-matrix composite
 // action: the changed-files trigger context plus the manual overrides.
 type PlanOptions struct {
-	// ActiveVersions are the active chart versions (chart-versions.yaml
-	// supportStandard), e.g. ["8.7", "8.8", "8.9", "8.10"].
+	// ActiveVersions are the routine chart versions from chartAutomation.routineVersions.
 	ActiveVersions []string
 	// ChangedFiles is the raw changed-files list (whitespace-separated, as
 	// emitted by tj-actions/changed-files with dir_names:true).
@@ -217,6 +216,10 @@ var buildAllTriggers = []buildAllTrigger{
 	{
 		Pattern:     regexp.MustCompile(`^test/e2e/`),
 		Description: "test/e2e/ (shared Playwright config)",
+	},
+	{
+		Pattern:     regexp.MustCompile(`^charts/chart-versions\.yaml$`),
+		Description: "charts/chart-versions.yaml (routine chart automation)",
 	},
 }
 

--- a/scripts/deploy-camunda/matrix/plan_test.go
+++ b/scripts/deploy-camunda/matrix/plan_test.go
@@ -76,6 +76,22 @@ func TestPlanManualAllBuildsNonEmpty(t *testing.T) {
 	}
 }
 
+func TestPlanChartVersionsChangeBuildsRoutineVersions(t *testing.T) {
+	t.Parallel()
+	result, err := Plan(findRepoRoot(t), PlanOptions{
+		ActiveVersions: planActiveVersions,
+		ChangedFiles:   "charts/chart-versions.yaml",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantVersions := append([]string(nil), planActiveVersions...)
+	sort.Strings(wantVersions)
+	if got, want := strings.Join(result.Versions, ","), strings.Join(wantVersions, ","); got != want {
+		t.Errorf("versions = %s, want routine versions %s", got, want)
+	}
+}
+
 func TestPlanManualSingleVersion(t *testing.T) {
 	result, err := Plan(findRepoRoot(t), PlanOptions{ActiveVersions: planActiveVersions, ManualTrigger: "8.9"})
 	if err != nil {

--- a/scripts/deploy-camunda/matrix/registry_test.go
+++ b/scripts/deploy-camunda/matrix/registry_test.go
@@ -450,7 +450,7 @@ func TestLoadRegistryCarriesExtraValues(t *testing.T) {
 func TestGenerate_PropagatesExtraValues(t *testing.T) {
 	dir, chartDir, regDir := syntheticChart(t)
 	writeFile(t, filepath.Join(dir, "charts", "chart-versions.yaml"),
-		"camundaVersions:\n  supportStandard:\n    - \"99.99\"\n")
+		"chartAutomation: {routineVersions: [\"99.99\"]}\ncamundaSupportLifecycle: {\"99.99\": {}}\n")
 	writeManifest(t, regDir, "    - id: alpha\n      shortname: alph\n      enabled: true\n")
 	writeFile(t, filepath.Join(regDir, "scenarios", "alpha.yaml"),
 		"name: alpha\nauth: keycloak\nflows: [install]\nidentity: keycloak\npersistence: elasticsearch\nplatforms: [gke]\nextra-values:\n  - values/extra/image.yaml\n")

--- a/scripts/deploy-camunda/matrix/upgrade_prev_version_test.go
+++ b/scripts/deploy-camunda/matrix/upgrade_prev_version_test.go
@@ -69,6 +69,12 @@ func TestUpgradeMinorPrevVersionDimensions(t *testing.T) {
 			t.Fatalf("LoadRegistry(%s): %v", version, err)
 		}
 
+		if !slices.ContainsFunc(cfg.Integration.Case.PR.Scenarios, func(s CIScenario) bool {
+			return slices.Contains(strings.Split(s.Flow, ","), "upgrade-minor")
+		}) {
+			continue
+		}
+
 		ids := mustListPrev(t, prevScenarioDir, scenarios.ListIdentities)
 		pers := mustListPrev(t, prevScenarioDir, scenarios.ListPersistence)
 		plats := mustListPrev(t, prevScenarioDir, scenarios.ListPlatforms)


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #7039.

Routine chart automation was derived from the `alpha` and `supportStandard` buckets in `charts/chart-versions.yaml`. Moving 8.7 out of standard support would therefore stop its routine CI, dev packaging, artifact verification, and Renovate maintenance chores even when its agreed ESUP delivery scope still requires chart maintenance.

Separately, ad-hoc validation of an Identity image against chart 8.6 failed at the matrix version gate. Removing that gate alone was insufficient: 8.6 had no CI scenario registry, so generation would skip the version without producing a deployment.

An ESUP entitlement does not automatically require routine Helm chart maintenance. The specific case's delivery scope determines whether a chart needs routine automation or only an explicit ad-hoc validation path.

### What's in this PR?

- Replace the `camundaVersions` buckets with `chartAutomation.routineVersions`. The routine set remains 8.10, 8.9, 8.8, and 8.7; changing a lifecycle date no longer changes automation membership.
- Retain `camundaSupportLifecycle` as the version inventory and lifecycle metadata. Derive the existing version-matrix groups from field presence, preserving the current headings, grouping, and rendered output. There is no ESUP presentation redesign or date-driven regrouping in this change.
- Reuse the shared configuration loader for matrix selection, prerelease detection, and latest-stable release metadata. Update workflow and script consumers, retain the used `active` action output, and remove unused bucket outputs. Documentation-link checks continue to exclude prerelease minors.
- Reject unknown YAML fields and require a non-empty routine list so mistakes in this manually maintained configuration fail validation instead of changing policy silently.
- Update the existing Minor Version Chores checklist: populate `released` and `stdSupportUntil` when a minor becomes GA, add the next prerelease to routine automation, and reconcile ongoing Helm chart maintenance against the ESUP case's scope without deleting lifecycle facts.
- Make changes to `charts/chart-versions.yaml` trigger the routine chart-test matrix.
- Add an opt-in 8.6 scenario registry for Elasticsearch (`es`), OpenSearch (`os`), and multitenancy (`mt`). All scenarios are disabled by default. Explicit `--versions 8.6 --include-disabled` yields six entries: Elasticsearch install and patch-upgrade on GKE/EKS, plus OpenSearch and multitenancy installs on GKE.
- Accept explicitly requested non-routine versions with a registry, retain EOL rejection in matrix generation, and return an actionable error when a requested non-routine version lacks a registry. Add manual multitenancy selection and remove workflow choices with no registry.
- Check for upgrade-minor scenarios before listing the previous version's values layers, avoiding an irrelevant failure for 8.6's legacy predecessor. Document the 8.6 replacement recipe, image overrides, and deployment-only validation limits.
- Register the shared golden-update flag in 8.6's common test package so the chart-wide chores command can run even though that package has no golden tests.

**Automated verification**

- Lifecycle, release metadata, prerelease, matrix, and command tests cover the new schema, independent routine membership, numeric latest-stable selection, and the GA handoff.
- Regression cases reject misspelled top-level, automation, and lifecycle fields, along with missing, empty, and null routine lists.
- The explicit 8.6 contract requires its registry and exact six-entry matrix, disabled/e2e-skip flags, and the key scenario configuration. Tests cover EOL and registry-less rejection and the configuration-change CI trigger.
- The deployment and release CLI suites pass uncached. CLI checks retain 80 default entries and six explicit 8.6 entries; workflow selector checks preserve the routine and released-routine sets.
- Old and new renderers produce byte-identical output for all eight generated per-minor pages and the index, using identical version-matrix data in isolated directories.
- Formatting, license, edited YAML, and shell-syntax checks pass.
- `make go.update-golden-only chartPath=charts/camunda-platform-8.6` and the 8.6 common-package tests pass without generated-file drift.

**Live verification and limits**

Three runs against the new 8.6 registry on distro-ci GKE reported `Success: 1, Failed: 0`:

| Run | Verified result |
|---|---|
| Install | Helm `deployed`, 22/22 pods ready, all five declared values layers resolved |
| In-place image override | Helm revision 2 `deployed`; Identity ran the overridden image and became ready |
| Two-step patch upgrade | Published chart `11.12.3` from `helm.camunda.io` installed in Step 1, then upgraded to the local chart in Step 2 |

The Identity override was verified using distinct running-container image IDs, not only tag strings:

```text
Before: camunda/identity:8.6.30
docker.io/camunda/identity@sha256:ece974111752db06038515a71ebcabca193cd2c960f61401b37f24331e77b285

After: camunda/identity:8.6.29
docker.io/camunda/identity@sha256:dffb114e4270ebc4863cc8d423588a76169cc78d9617aa715147cc7014c1ca6f
```

The overridden pod became ready, logged no error/exception lines, connected successfully to Keycloak, and had no pull failures. OIDC discovery returned the expected issuer at `/auth/realms/camunda-platform/.well-known/openid-configuration`.

8.6 gains opt-in deployment validation, not compatible cross-component e2e fixtures. Every 8.6 scenario sets `skip-e2e: true`, which overrides `--test-e2e` and `--test-all`. The patch-upgrade run proves the published-chart-to-local two-step mechanism, not a cross-version migration: both steps used chart version `11.12.3`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?