### PR TITLE
feat(8.10): announce Operate and Tasklist locations for well-known discovery

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -238,6 +238,27 @@ camunda:
     multiTenancy:
       checksEnabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
       apiEnabled: {{ include "orchestration.multitenancyApiEnabled" . }}
+  # Webapp UI locations announced via the /.well-known/camunda/webapps discovery endpoint
+  # (camunda/camunda#46649). Absolute URLs derived from the ingress configuration take
+  # precedence over the cluster's relative-path fallback; disabled webapps are never announced.
+  # Mirrors orchestration.enabledProfiles: with global.noSecondaryStorage the Operate/Tasklist
+  # profiles are dropped, so they are not announced either. An absolute URL is set only when the
+  # chart knows a real external host; in the localhost fallback (no ingress/gateway) the endpoint's
+  # relative-path default is strictly better, as it resolves against the origin the client used.
+  {{- $operateEnabled := and .Values.orchestration.profiles.operate (not .Values.global.noSecondaryStorage) }}
+  {{- $tasklistEnabled := and .Values.orchestration.profiles.tasklist (not .Values.global.noSecondaryStorage) }}
+  {{- $externalHostKnown := and (or .Values.global.ingress.enabled .Values.global.gateway.enabled) (tpl .Values.global.host .) }}
+  webapps:
+    operate:
+      enabled: {{ $operateEnabled }}
+      {{- if and $operateEnabled $externalHostKnown }}
+      url: {{ include "camundaPlatform.operateExternalURL" . | quote }}
+      {{- end }}
+    tasklist:
+      enabled: {{ $tasklistEnabled }}
+      {{- if and $tasklistEnabled $externalHostKnown }}
+      url: {{ include "camundaPlatform.tasklistExternalURL" . | quote }}
+      {{- end }}
   {{- if .Values.orchestration.hub.ping.endpoint }}
   hub:
     ping:

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -105,6 +105,98 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 			},
 		},
 		{
+			Name: "TestApplicationYamlShouldContainWebappsDiscoveryUrls",
+			Values: map[string]string{
+				"global.ingress.enabled":     "true",
+				"global.host":                "camunda.example.com",
+				"global.ingress.tls.enabled": "true",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.webapps.operate.enabled":  "true",
+				"configmapApplication.camunda.webapps.operate.url":      "https://camunda.example.com/operate",
+				"configmapApplication.camunda.webapps.tasklist.enabled": "true",
+				"configmapApplication.camunda.webapps.tasklist.url":     "https://camunda.example.com/tasklist",
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldContainWebappsDiscoveryUrlsWithContextPath",
+			Values: map[string]string{
+				"global.ingress.enabled":    "true",
+				"global.host":               "camunda.example.com",
+				"orchestration.contextPath": "/custom",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.webapps.operate.url":  "http://camunda.example.com/custom/operate",
+				"configmapApplication.camunda.webapps.tasklist.url": "http://camunda.example.com/custom/tasklist",
+			},
+		},
+		{
+			Name:   "TestApplicationYamlShouldOmitWebappsUrlsWithoutExternalHost",
+			Values: map[string]string{},
+			Expected: map[string]string{
+				// without ingress/gateway the chart knows no real external host, so it leaves the
+				// URLs to the endpoint's relative-path fallback instead of guessing localhost
+				"configmapApplication.camunda.webapps.operate.enabled":  "true",
+				"configmapApplication.camunda.webapps.tasklist.enabled": "true",
+			},
+			Unexpected: []string{
+				"configmapApplication.camunda.webapps.operate.url",
+				"configmapApplication.camunda.webapps.tasklist.url",
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldOmitWebappsUrlsWithHostlessIngress",
+			Values: map[string]string{
+				"global.ingress.enabled": "true",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.webapps.operate.enabled":  "true",
+				"configmapApplication.camunda.webapps.tasklist.enabled": "true",
+			},
+			Unexpected: []string{
+				"configmapApplication.camunda.webapps.operate.url",
+				"configmapApplication.camunda.webapps.tasklist.url",
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldContainWebappsDiscoveryUrlsWithGatewayApi",
+			Values: map[string]string{
+				"global.gateway.enabled": "true",
+				"global.host":            "camunda.example.com",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.webapps.operate.url":  "http://camunda.example.com/operate",
+				"configmapApplication.camunda.webapps.tasklist.url": "http://camunda.example.com/tasklist",
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldNotAnnounceDisabledWebapp",
+			Values: map[string]string{
+				"orchestration.profiles.operate": "false",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.webapps.operate.enabled":  "false",
+				"configmapApplication.camunda.webapps.tasklist.enabled": "true",
+			},
+			Unexpected: []string{
+				"configmapApplication.camunda.webapps.operate.url",
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldNotAnnounceWebappsWithoutSecondaryStorage",
+			Values: map[string]string{
+				"global.noSecondaryStorage": "true",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.webapps.operate.enabled":  "false",
+				"configmapApplication.camunda.webapps.tasklist.enabled": "false",
+			},
+			Unexpected: []string{
+				"configmapApplication.camunda.webapps.operate.url",
+				"configmapApplication.camunda.webapps.tasklist.url",
+			},
+		},
+		{
 			Name: "TestApplicationYamlShouldContainSecondaryStorageOpenSearchEnabled",
 			Values: map[string]string{
 				"orchestration.data.secondaryStorage.type":           "opensearch",

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -142,6 +142,18 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
+      # Webapp UI locations announced via the /.well-known/camunda/webapps discovery endpoint
+      # (camunda/camunda#46649). Absolute URLs derived from the ingress configuration take
+      # precedence over the cluster's relative-path fallback; disabled webapps are never announced.
+      # Mirrors orchestration.enabledProfiles: with global.noSecondaryStorage the Operate/Tasklist
+      # profiles are dropped, so they are not announced either. An absolute URL is set only when the
+      # chart knows a real external host; in the localhost fallback (no ingress/gateway) the endpoint's
+      # relative-path default is strictly better, as it resolves against the origin the client used.
+      webapps:
+        operate:
+          enabled: true
+        tasklist:
+          enabled: true
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -142,6 +142,18 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
+      # Webapp UI locations announced via the /.well-known/camunda/webapps discovery endpoint
+      # (camunda/camunda#46649). Absolute URLs derived from the ingress configuration take
+      # precedence over the cluster's relative-path fallback; disabled webapps are never announced.
+      # Mirrors orchestration.enabledProfiles: with global.noSecondaryStorage the Operate/Tasklist
+      # profiles are dropped, so they are not announced either. An absolute URL is set only when the
+      # chart knows a real external host; in the localhost fallback (no ingress/gateway) the endpoint's
+      # relative-path default is strictly better, as it resolves against the origin the client used.
+      webapps:
+        operate:
+          enabled: true
+        tasklist:
+          enabled: true
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-rdbms.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-rdbms.golden.yaml
@@ -133,6 +133,18 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
+      # Webapp UI locations announced via the /.well-known/camunda/webapps discovery endpoint
+      # (camunda/camunda#46649). Absolute URLs derived from the ingress configuration take
+      # precedence over the cluster's relative-path fallback; disabled webapps are never announced.
+      # Mirrors orchestration.enabledProfiles: with global.noSecondaryStorage the Operate/Tasklist
+      # profiles are dropped, so they are not announced either. An absolute URL is set only when the
+      # chart knows a real external host; in the localhost fallback (no ingress/gateway) the endpoint's
+      # relative-path default is strictly better, as it resolves against the origin the client used.
+      webapps:
+        operate:
+          enabled: true
+        tasklist:
+          enabled: true
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -146,6 +146,18 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
+      # Webapp UI locations announced via the /.well-known/camunda/webapps discovery endpoint
+      # (camunda/camunda#46649). Absolute URLs derived from the ingress configuration take
+      # precedence over the cluster's relative-path fallback; disabled webapps are never announced.
+      # Mirrors orchestration.enabledProfiles: with global.noSecondaryStorage the Operate/Tasklist
+      # profiles are dropped, so they are not announced either. An absolute URL is set only when the
+      # chart knows a real external host; in the localhost fallback (no ingress/gateway) the endpoint's
+      # relative-path default is strictly better, as it resolves against the origin the client used.
+      webapps:
+        operate:
+          enabled: true
+        tasklist:
+          enabled: true
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
@@ -142,6 +142,18 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
+      # Webapp UI locations announced via the /.well-known/camunda/webapps discovery endpoint
+      # (camunda/camunda#46649). Absolute URLs derived from the ingress configuration take
+      # precedence over the cluster's relative-path fallback; disabled webapps are never announced.
+      # Mirrors orchestration.enabledProfiles: with global.noSecondaryStorage the Operate/Tasklist
+      # profiles are dropped, so they are not announced either. An absolute URL is set only when the
+      # chart knows a real external host; in the localhost fallback (no ingress/gateway) the endpoint's
+      # relative-path default is strictly better, as it resolves against the origin the client used.
+      webapps:
+        operate:
+          enabled: true
+        tasklist:
+          enabled: true
       persistent:
         sessions:
           enabled: true


### PR DESCRIPTION
### Which problem does this PR fix?

Relates to camunda/camunda#46649

Depends on core PR: camunda/camunda#62899

Client applications (e.g. the Desktop Modeler, `c8ctl`) cannot know where a self-managed setup's Operate and Tasklist UIs live; users configure each UI URL separately in every client.

### What's in this PR?

The core repo adds an unauthenticated `GET /.well-known/camunda/webapps` endpoint that announces explicitly configured `camunda.webapps.<app>.url` values as-is and otherwise falls back to the webapp's default path relative to the API origin. That fallback is correct only when the webapps share the API's origin and layout — which the chart knows from its routing configuration.

This PR writes `camunda.webapps.operate/tasklist` into the orchestration `application.yaml`:

- `enabled` mirrors the component profile, including the `global.noSecondaryStorage` profile drop (profiles bypass the property, so without this a disabled webapp would still be announced).
- `url` is set to the absolute external URL the chart already computes (`camundaPlatform.operateExternalURL`/`tasklistExternalURL`) — but only when a real external host is known (ingress or Gateway API). In the localhost fallback the property is omitted, because the endpoint's relative-path fallback resolves correctly against whatever origin the client actually used.

Unit tests cover the ingress, contextPath, disabled-profile, no-secondary-storage, and no-external-host scenarios; golden files regenerated.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only` (golden files updated via `-update-golden`).
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo documentation is updated (no new values keys; behavior documented in the template comments).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?